### PR TITLE
Fix tooltips and knobs jumping when switching knobsets

### DIFF
--- a/src/hub/hub_map_button.cc
+++ b/src/hub/hub_map_button.cc
@@ -33,7 +33,7 @@ void HubMapButton::onDragStart(const rack::event::DragStart &e) {
 	if (e.button != GLFW_MOUSE_BUTTON_LEFT) {
 		return;
 	}
-	
+
 	start_mapping();
 
 	// ???What is this?
@@ -61,7 +61,8 @@ void HubMapButton::onHover(const rack::event::Hover &e) {
 	if (hub) {
 		auto &maps = hub->mappings.getAllMappings(hubParamObj.objID);
 		for (auto &map : maps) {
-			map.paramHandle.color = (flash < flash_rate / 2) ? PaletteHub::color(hubParamObj.objID) : PaletteHub::WHITE;
+			map.paramHandle.color = (flash < flash_rate / 2) ? PaletteHub::color(hubParamObj.objID) :
+															   PaletteHub::flash_color(hubParamObj.objID);
 		}
 		flash = flash ? flash - 1 : flash_rate;
 	}

--- a/src/hub/hub_map_button.hh
+++ b/src/hub/hub_map_button.hh
@@ -21,7 +21,6 @@ public:
 	bool isMapped = false;
 	MappableObj mappedToId{MappableObj::Type::None, -1, -1};
 
-	// void _createMapping(LabelButtonID srcId);
 protected:
 	bool hovered{false};
 	rack::app::ModuleWidget &parent;

--- a/src/hub/hub_module_widget.hh
+++ b/src/hub/hub_module_widget.hh
@@ -90,9 +90,11 @@ struct MetaModuleHubWidget : rack::app::ModuleWidget {
 	}
 
 	void onHover(const HoverEvent &e) override {
+		rack::app::ModuleWidget::onHover(e);
 		if (hubModule->should_write_patch()) {
 			hubModule->mappings.removeMapsToDeletedModules();
 			hubModule->writePatchFile();
+			e.consume(this);
 		}
 	}
 

--- a/src/mapping/map_marks.hh
+++ b/src/mapping/map_marks.hh
@@ -39,7 +39,7 @@ struct MapMark {
 		nvgFillColor(vg, color);
 		nvgFill(vg);
 		nvgStrokeColor(vg, rack::color::mult(color, 0.5));
-		nvgStrokeWidth(vg, 1.0);
+		nvgStrokeWidth(vg, 1.f);
 		nvgStroke(vg);
 	}
 };

--- a/src/mapping/map_palette.hh
+++ b/src/mapping/map_palette.hh
@@ -28,17 +28,21 @@ private:
 		MAGENTA,
 		ORANGE,
 		GREEN,
-		//TODO: less saturated for the knobs u-z?
-		RED,
-		YELLOW,
-		CYAN,
-		MAGENTA,
-		ORANGE,
-		GREEN,
+
+		rack::color::mult(RED, 0.65f),
+		rack::color::mult(YELLOW, 0.65f),
+		rack::color::mult(CYAN, 0.65f),
+		rack::color::mult(MAGENTA, 0.65f),
+		rack::color::mult(ORANGE, 0.65f),
+		rack::color::mult(GREEN, 0.65f),
 	};
 
 public:
 	static NVGcolor color(unsigned idx) {
 		return _color[idx % _color.size()];
+	}
+
+	static NVGcolor flash_color(unsigned idx) {
+		return idx == 1 || idx == 2 || idx == 7 || idx == 8 ? BLACK : WHITE;
 	}
 };

--- a/src/scaling_config.hh
+++ b/src/scaling_config.hh
@@ -1,7 +1,0 @@
-#pragma once
-
-static inline constexpr float InputLowRangeVolts = -5.f;
-static inline constexpr float InputHighRangeVolts = 5.f;
-
-static inline constexpr float OutputLowRangeVolts = -5.f;
-static inline constexpr float OutputHighRangeVolts = 5.f;

--- a/src/sys/alloc_buffer.hh
+++ b/src/sys/alloc_buffer.hh
@@ -1,6 +1,0 @@
-#pragma once
-
-template<typename T>
-using BigAlloc = T;
-
-struct BigHeapAllocation {};


### PR DESCRIPTION
Fixes tooltips were not disappearing if a jack was clicked.
And now mapped knobs won't change value if you change knob sets: they only change value if you move the hub knob.