### PR TITLE
Fix identical knob maps in different knob sets

### DIFF
--- a/src/console/pr_dbg.hh
+++ b/src/console/pr_dbg.hh
@@ -1,5 +1,11 @@
-#define pr_dbg printf
-#define pr_info printf
-#define pr_warn printf
-#define pr_err printf
-#define pr_trace printf
+// #define pr_dbg printf
+// #define pr_info printf
+// #define pr_warn printf
+// #define pr_err printf
+// #define pr_trace printf
+
+#define pr_dbg(x, ...)
+#define pr_info(x, ...)
+#define pr_warn(x, ...)
+#define pr_err(x, ...)
+#define pr_trace(x, ...)

--- a/src/hub/hub_elements.hh
+++ b/src/hub/hub_elements.hh
@@ -1,6 +1,7 @@
 #pragma once
 #include "CoreModules/elements/element_counter.hh"
 #include "CoreModules/elements/elements.hh"
+#include "console/pr_dbg.hh"
 #include "hub/hub_module_widget.hh"
 #include "widgets/4ms/4ms_widgets.hh"
 
@@ -16,7 +17,7 @@ namespace HubWidgetImpl
 {
 
 inline void do_create(BaseElement element, const ElementCount::Indices &, const HubWidgetContext &) {
-	printf("Hub Widget not found\n");
+	pr_dbg("Hub Widget not found\n");
 }
 
 inline void do_create(Knob el, const ElementCount::Indices &idx, const HubWidgetContext &ctx) {

--- a/src/hub/hub_knob_mappings.hh
+++ b/src/hub/hub_knob_mappings.hh
@@ -13,7 +13,6 @@
 // 5) which will notice the paramHandle is gone, and thus delete the map
 // 6) Then, hub::encodeJson is called and writes out json without that map
 
-//Rename HubKnobMapManager
 template<size_t NumKnobs, size_t MaxMapsPerPot, size_t MaxKnobSets = 8>
 class HubKnobMappings {
 	int64_t hubModuleId = -1;
@@ -28,9 +27,9 @@ public:
 	using KnobMultiMap = std::array<KnobMappingSet, MaxMapsPerPot>;
 	using HubKnobsMultiMaps = std::array<KnobMultiMap, NumKnobs>;
 	HubKnobsMultiMaps mappings;
+	//mappings[KnobId][MultiMapId].maps[KnobSetID].moduleId/paramId
 
 	std::array<std::string, MaxKnobSets> knobSetNames;
-	// TODO aliases
 	std::array<std::array<StaticString<31>, MaxKnobSets>, NumKnobs> aliases;
 
 	HubKnobMappings() {

--- a/src/hub/hub_knob_mappings.hh
+++ b/src/hub/hub_knob_mappings.hh
@@ -350,7 +350,12 @@ private:
 		for (auto &knob : mappings) {
 			for (auto &mapset : knob) {
 				Mapping &map = mapset.maps[activeSetId];
-				APP->engine->updateParamHandle(&mapset.paramHandle, map.moduleId, map.paramId, true);
+				// Calling updateParamHandle(ph, m, p) where ph.moduleId == m && ph.paramId == p,
+				// will remove paramHandle from the engine. That is, calling updateParamHandle()
+				// without changing the module or param values will delete the paramHandle.
+				// To fix this, rack::Engine would need to check if oldParamHandle == paramHandle
+				if (mapset.paramHandle.moduleId != map.moduleId || mapset.paramHandle.paramId != map.paramId)
+					APP->engine->updateParamHandle(&mapset.paramHandle, map.moduleId, map.paramId, true);
 			}
 		}
 	}

--- a/src/hub/hub_module.hh
+++ b/src/hub/hub_module.hh
@@ -1,5 +1,6 @@
 #pragma once
 #include "comm/comm_module.hh"
+#include "hub/hub_module.hh"
 #include "hub_knob_mappings.hh"
 #include "mapping/module_directory.hh"
 #include "mapping/vcv_patch_file_writer.hh"
@@ -8,9 +9,6 @@
 #include "util/string_util.hh"
 #include <osdialog.h>
 #include <span>
-
-// #define pr_dbg printf
-#define pr_dbg(x, ...)
 
 struct MetaModuleHubBase : public rack::Module {
 
@@ -147,7 +145,7 @@ struct MetaModuleHubBase : public rack::Module {
 			json_t *defaultKnobSetJ = json_integer(mappings.getActiveKnobSetIdx());
 			json_object_set_new(rootJ, "DefaultKnobSet", defaultKnobSetJ);
 		} else
-			printf("Error: Widget has not been constructed, but dataToJson is being called\n");
+			pr_dbg("Error: Widget has not been constructed, but dataToJson is being called\n");
 		return rootJ;
 	}
 

--- a/src/hub/hub_module.hh
+++ b/src/hub/hub_module.hh
@@ -55,7 +55,7 @@ struct MetaModuleHubBase : public rack::Module {
 
 	bool registerMap(int hubParamId, rack::Module *module, int64_t moduleParamId) {
 		if (!isMappingInProgress()) {
-			pr_dbg("Error: registerMap() called but we aren't mapping!\n");
+			pr_dbg("registerMap() called but we aren't mapping\n");
 			return false;
 		}
 
@@ -74,7 +74,7 @@ struct MetaModuleHubBase : public rack::Module {
 		mappings.linkToModule(id);
 		auto *map = mappings.addMap(hubParamId, module->id, moduleParamId);
 		if (!map) {
-			printf("Error: could not create mapping\n");
+			pr_dbg("Error: could not create mapping\n");
 			return false;
 		}
 

--- a/src/hub/hub_module_widget.hh
+++ b/src/hub/hub_module_widget.hh
@@ -62,33 +62,6 @@ struct MetaModuleHubWidget : rack::app::ModuleWidget {
 		addParam(p);
 	}
 
-	void addMidiValueMapSrc(const std::string labelText, int knobId, rack::math::Vec posPx, MappableObj::Type type) {
-		auto *button = new HubMidiMapButton{hubModule, *this};
-		button->box.size.x = rack::mm2px(13.5);
-		button->box.size.y = rack::mm2px(5.6);
-		button->box.pos = posPx;
-		button->box.pos = button->box.pos.minus(button->box.size.div(2));
-		button->text = labelText;
-		button->hubParamObj = {type, knobId, hubModule ? hubModule->id : -1};
-		addChild(button);
-
-		auto *p = new HubMidiParam{hubModule, *button};
-		p->setSize(rack::mm2px({12, 4}));
-		p->box.pos = posPx;
-		p->box.pos = p->box.pos.minus(p->box.size.div(2));
-		p->rack::app::ParamWidget::module = hubModule;
-		p->rack::app::ParamWidget::paramId = knobId;
-		p->initParamQuantity();
-
-		if (module) {
-			auto pq = p->getParamQuantity();
-			pq = module->paramQuantities[knobId];
-			pq->defaultValue = 0.f;
-			button->setParamQuantity(pq);
-		}
-		addParam(p);
-	}
-
 	void onHover(const HoverEvent &e) override {
 		rack::app::ModuleWidget::onHover(e);
 		if (hubModule->should_write_patch()) {

--- a/src/mapping/patch_writer.cc
+++ b/src/mapping/patch_writer.cc
@@ -1,4 +1,5 @@
 #include "patch_writer.hh"
+#include "console/pr_dbg.hh"
 #include "mapping/midi_modules.hh"
 #include "mapping/module_directory.hh"
 #include "patch-serial/patch_to_yaml.hh"
@@ -207,7 +208,7 @@ void PatchFileWriter::addKnobMaps(unsigned panelKnobId, unsigned knobSetId, cons
 
 	for (const auto &m : maps) {
 		if (!idMap.contains(m.moduleId)) {
-			printf("Skipping knob mapping to module not supported by MetaModule: %lld\n", (long long)m.moduleId);
+			pr_dbg("Skipping knob mapping to module not supported by MetaModule: %lld\n", (long long)m.moduleId);
 			continue;
 		}
 		pd.knob_sets[knobSetId].set.push_back({

--- a/src/mapping/vcv_patch_file_writer.hh
+++ b/src/mapping/vcv_patch_file_writer.hh
@@ -1,4 +1,5 @@
 #pragma once
+#include "console/pr_dbg.hh"
 #include "cpputil/util/colors.hh"
 #include "hub/hub_knob_mappings.hh"
 #include "mapping/JackMap.hh"
@@ -43,7 +44,7 @@ struct VCVPatchFileWriter {
 				auto brand_module = ModuleDirectory::convertSlugs(module);
 				moduleData.push_back({moduleID, brand_module.c_str()});
 				if (module->model->slug.size() > 31)
-					printf("Warning: module slug truncated to 31 chars\n");
+					pr_dbg("Warning: module slug truncated to 31 chars\n");
 
 				if (!ModuleDirectory::isHub(module)) {
 					for (size_t i = 0; i < module->paramQuantities.size(); i++) {

--- a/src/widgets/vcv_module_creator.hh
+++ b/src/widgets/vcv_module_creator.hh
@@ -1,6 +1,7 @@
 #pragma once
 #include "CoreModules/elements/element_counter.hh"
 #include "base_modules_implemenation.hh"
+#include "console/pr_dbg.hh"
 #include "vcv_creation_context.hh"
 
 namespace MetaModule::VCVImplementation::Module
@@ -9,7 +10,7 @@ namespace MetaModule::VCVImplementation::Module
 inline void do_config_element(BaseElement el, const ElementCount::Indices &, const ModuleContext_t &) {
 	// Do nothing by default
 	// FIXME: This should probably be replaced with more specific fallbacks
-	printf("Element not configured (%.*s)\n", (int)el.short_name.size(), el.short_name.data());
+	pr_dbg("Element not configured (%.*s)\n", (int)el.short_name.size(), el.short_name.data());
 };
 } // namespace MetaModule::VCVImplementation::Module
 

--- a/src/widgets/vcv_widget_creator.hh
+++ b/src/widgets/vcv_widget_creator.hh
@@ -1,9 +1,10 @@
 #pragma once
+#include "4ms/4ms_widgets_implementation.hh"
 #include "CoreModules/elements/element_counter.hh"
 #include "CoreModules/elements/elements.hh"
-#include "vcv_creation_context.hh"
-#include "4ms/4ms_widgets_implementation.hh"
 #include "alt_params_implementation.h"
+#include "console/pr_dbg.hh"
+#include "vcv_creation_context.hh"
 
 namespace MetaModule::VCVImplementation::Widget
 {
@@ -11,13 +12,14 @@ namespace MetaModule::VCVImplementation::Widget
 inline void do_create(BaseElement element, const ElementCount::Indices &, const WidgetContext_t &) {
 	// Default: do nothing
 	// FIXME: Maybe this should be replaced with more specific fallbacks
-	printf("Creating of element '%.*s' not defined\n", int(element.short_name.size()), element.short_name.data());
+	pr_dbg("Creating of element '%.*s' not defined\n", int(element.short_name.size()), element.short_name.data());
 }
 
-inline void do_render_to_menu(BaseElement element, rack::ui::Menu* menu, Indices &, const WidgetContext_t &) {
-	printf("Rendering to context menu not defined for element '%.*s'\n", int(element.short_name.size()), element.short_name.data());
+inline void do_render_to_menu(BaseElement element, rack::ui::Menu *menu, Indices &, const WidgetContext_t &) {
+	pr_dbg("Rendering to context menu not defined for element '%.*s'\n",
+		   int(element.short_name.size()),
+		   element.short_name.data());
 }
-
 
 } // namespace MetaModule::VCVImplementation::Widget
 
@@ -32,11 +34,9 @@ struct VCVWidgetCreator {
 	}
 
 	template<typename EL>
-	void create(const EL &element)
-	{
+	void create(const EL &element) {
 		// alt parameters do not have a widget
-		if constexpr (not std::derived_from<EL,MetaModule::AltParamElement>)
-		{
+		if constexpr (not std::derived_from<EL, MetaModule::AltParamElement>) {
 			// forward to implementation together with current context
 			if (auto indices = ElementCount::get_indices<INFO>(element)) {
 				VCVImplementation::Widget::do_create(element, indices.value(), context);
@@ -44,12 +44,10 @@ struct VCVWidgetCreator {
 		}
 	}
 
-	template <typename EL>
-	void renderToContextMenu(const EL& element, rack::ui::Menu *menu)
-	{
+	template<typename EL>
+	void renderToContextMenu(const EL &element, rack::ui::Menu *menu) {
 		// only alt parameters are considered for rendering to menu for now
-		if constexpr (std::derived_from<EL,MetaModule::AltParamElement>)
-		{
+		if constexpr (std::derived_from<EL, MetaModule::AltParamElement>) {
 			// forward to implementation with required context
 			if (auto indices = ElementCount::get_indices<INFO>(element)) {
 				VCVImplementation::Widget::do_render_to_menu(element, menu, indices.value(), context);


### PR DESCRIPTION
Fixes #16 

Creating an identical knob map in two Knob Sets would erase one of them when switching to its knob set.
E.g. map hub Knob A to VCO Freq in knob set 1. Then map hub Knob A to VCO Freq in knob set 2. Then switch back to knob set 1, and Knob A is no longer mapped.

The reason was that the rack engine removes a ParamHandle if `updateParamHandle()` is called with a moduleId and paramId that match what the paramHandle is already set to. Instead of ignoring the update request, rack removes the paramHandle from the engine's vector of ParamHandles, as well as its cache. 
Then the Hub sees an invalid paramHandle and removes it from the mappings.
I did not find any documentation of this behavior, and given that there already is a documented way to remove a paramHandle using `updateParamHandle` (call it with a moduleId == -1), this might be a bug?

In any case, the workaround is to not call `updateParamHandle` if the module and param ID are unchanged.
