### PR TITLE
Enosc Pitch CV and Root CV range extended to -8V...+8V

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,19 @@ make install
 
 The next time you start VCV Rack, it will load the modified plugin.
 
+If you are developing or modifying the code, then use the cmake interface for building (it will handle dependencies and rebuild only what needs to):
+
+```
+# Configure cmake (only need to do this once):
+make dep
+
+# Then do this to rebuild after making changes:
+cmake --build build
+
+# Install normally:
+make install
+
+```
 
 To run the unit tests:
 

--- a/tests/rack.hpp
+++ b/tests/rack.hpp
@@ -41,6 +41,9 @@ struct Module {
 	json_t *dataToJson() {
 		return nullptr;
 	}
+	Model *getModel() {
+		return model;
+	}
 };
 
 struct ParamHandle {
@@ -52,7 +55,7 @@ struct ParamHandle {
 	NVGcolor color;
 };
 
-struct Cable{};
+struct Cable {};
 
 struct _Engine {
 	void removeParamHandle(rack::ParamHandle *) {


### PR DESCRIPTION
Brings in change from CoreModules to extend range of EnOsc Pitch CV and Root CV jacks.
Previously they were -5V to +5V. For reference, original hardware EnOsc is -2V to +6V.