### PR TITLE
Linux builds with static libstdc++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,9 @@ rack_plugin: $(cmake_rack_plugin)
 # Add files to the ZIP package when running `make dist`
 dist: rack_plugin res
 
+configure:
+	$(CMAKE) -B $(CMAKE_BUILD) -DRACK_SDK_DIR=$(RACK_DIR) -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(CMAKE_BUILD)/dist $(EXTRA_CMAKE)
+
 DISTRIBUTABLES += $(wildcard LICENSE*) res README.md 
 
 # Include the VCV plugin Makefile framework

--- a/RackSDK.cmake
+++ b/RackSDK.cmake
@@ -40,6 +40,11 @@ set(PLUGIN_DISTRIBUTABLES plugin.json res ${LICENSE} ${ADDITIONAL_PLUGIN_DISTRIB
 
 message(STATUS "PLUGIN_DISTRIBUTABLES: ${PLUGIN_DISTRIBUTABLES}")
 
+# Since the plugin's compiler could be a different version than Rack's compiler, link libstdc++ and libgcc statically to avoid ABI issues.
+add_link_options($<$<CXX_COMPILER_ID:GNU>:-static-libstdc++>)
+add_link_options($<$<PLATFORM_ID:Linux>:-static-libgcc>)
+add_compile_options($<IF:$<STREQUAL:${CMAKE_OSX_ARCHITECTURES},arm64>,-march=armv8-a+fp+simd,-march=nehalem>)
+
 add_compile_options(-fvisibility=hidden $<$<COMPILE_LANGUAGE:CXX>:-fvisibility-inlines-hidden>)
 # This is needed for Rack for DAWs.
 # Static libs don't usually compiled with -fPIC, but since we're including them in a shared library, it's needed.
@@ -69,10 +74,6 @@ endif()
 
 add_library(${RACK_PLUGIN_LIB} MODULE)
 set_target_properties(${RACK_PLUGIN_LIB} PROPERTIES PREFIX "")
-
-# Since the plugin's compiler could be a different version than Rack's compiler, link libstdc++ and libgcc statically to avoid ABI issues.
-add_link_options($<$<CXX_COMPILER_ID:GNU>:-static-libstdc++> $<$<PLATFORM_ID:Linux>:-static-libgcc>)
-add_compile_options($<IF:$<STREQUAL:${CMAKE_OSX_ARCHITECTURES},arm64>,-march=armv8-a+fp+simd,-march=nehalem>)
 
 add_library(RackSDK INTERFACE)
 target_include_directories(RackSDK INTERFACE ${RACK_SDK_DIR}/include ${RACK_SDK_DIR}/dep/include)


### PR DESCRIPTION
This adds the flags `-static-libstdc++` and `-static-libgcc` when linking with gcc, particularly on Linux (Apple uses clang and Windows already has the flag added).

Fixes ABI issues, e.g. see: https://community.vcvrack.com/t/4ms-meta-rackception/20558/160