### PR TITLE
Tapo CV fix, and fix default values for AltParamChoice

### DIFF
--- a/src/widgets/alt_params_implementation.h
+++ b/src/widgets/alt_params_implementation.h
@@ -26,7 +26,7 @@ struct AltParamChoiceItem : rack::ui::MenuItem {
 	}
 	void draw(const DrawArgs &args) override {
 		// add checkmark if this choice is selected
-		auto currentState = std::clamp<unsigned>(std::round(module->getParam(param_idx).getValue()), 1, el.num_pos);
+		auto currentState = std::clamp<unsigned>(std::round(module->getParam(param_idx).getValue()), 0, el.num_pos - 1);
 		rightText = currentState == choiceIndex ? CHECKMARK_STRING : " ";
 
 		rack::ui::MenuItem::draw(args);
@@ -54,7 +54,7 @@ struct AltParamChoiceLabledMenu : rack::ui::MenuItem {
 		auto childMenu = new rack::ui::Menu;
 
 		for (std::size_t i = 0; i < element.num_pos; i++) {
-			auto choiceItem = new AltParamChoiceItem(module, param_idx, element, i + 1);
+			auto choiceItem = new AltParamChoiceItem(module, param_idx, element, i);
 			auto choiceText = element.pos_names[i];
 			choiceItem->text = std::string(choiceText);
 			childMenu->addChild(choiceItem);

--- a/src/widgets/alt_params_implementation.h
+++ b/src/widgets/alt_params_implementation.h
@@ -94,6 +94,18 @@ struct QuantizedSlider : public rack::ui::Slider {
 		}
 	}
 
+	void draw(const DrawArgs &args) override {
+		BNDwidgetState state = BND_DEFAULT;
+		if (APP->event->hoveredWidget == this)
+			state = BND_HOVER;
+		if (APP->event->draggedWidget == this)
+			state = BND_ACTIVE;
+
+		float progress = quantity ? quantity->getScaledValue() : 0.f;
+		std::string text = quantity ? std::to_string(int(quantity->getValue() + 1)) : "";
+		bndSlider(args.vg, 0.0, 0.0, box.size.x, box.size.y, BND_CORNER_NONE, state, progress, text.c_str(), NULL);
+	}
+
 	float accumulatedDrag = 0.0f;
 };
 

--- a/src/widgets/alt_params_implementation.h
+++ b/src/widgets/alt_params_implementation.h
@@ -1,6 +1,6 @@
 #include "rack.hpp"
-#include <algorithm>
 #include <CoreModules/elements/element_state_conversion.hh>
+#include <algorithm>
 
 namespace MetaModule::VCVImplementation::Widget
 {
@@ -10,22 +10,21 @@ namespace MetaModule::VCVImplementation::Widget
  * for a single paramter on a module instance
  */
 
-struct AltParamChoiceItem : rack::ui::MenuItem
-{
-    AltParamChoiceItem(rack::Module* module_, std::size_t param_idx_, AltParamChoiceLabeled el_, std::size_t choiceIndex_)
+struct AltParamChoiceItem : rack::ui::MenuItem {
+	AltParamChoiceItem(rack::Module *module_,
+					   std::size_t param_idx_,
+					   AltParamChoiceLabeled el_,
+					   std::size_t choiceIndex_)
 		: module(module_)
 		, param_idx(param_idx_)
 		, el(el_)
-		, choiceIndex(choiceIndex_)
-		{};
-    void onAction(const ActionEvent& e) override
-    {
-        e.unconsume();
+		, choiceIndex(choiceIndex_){};
+	void onAction(const ActionEvent &e) override {
+		e.unconsume();
 
-        module->getParam(param_idx).setValue(choiceIndex);
-    }
-	void draw(const DrawArgs& args) override
-	{
+		module->getParam(param_idx).setValue(choiceIndex);
+	}
+	void draw(const DrawArgs &args) override {
 		// add checkmark if this choice is selected
 		auto currentState = std::clamp<unsigned>(std::round(module->getParam(param_idx).getValue()), 1, el.num_pos);
 		rightText = currentState == choiceIndex ? CHECKMARK_STRING : " ";
@@ -34,52 +33,47 @@ struct AltParamChoiceItem : rack::ui::MenuItem
 	}
 
 private:
-    rack::Module* module;
-    std::size_t param_idx;
-    AltParamChoiceLabeled el;
-    std::size_t choiceIndex;
+	rack::Module *module;
+	std::size_t param_idx;
+	AltParamChoiceLabeled el;
+	std::size_t choiceIndex;
 };
 
 /*
  * Submenu that holds all options for a single alt paramter on a module instance
  */
 
-struct AltParamChoiceLabledMenu : rack::ui::MenuItem
-{
-    AltParamChoiceLabledMenu(rack::Module* module_, std::size_t param_idx_, AltParamChoiceLabeled el)
+struct AltParamChoiceLabledMenu : rack::ui::MenuItem {
+	AltParamChoiceLabledMenu(rack::Module *module_, std::size_t param_idx_, AltParamChoiceLabeled el)
 		: module(module_)
 		, param_idx(param_idx_)
-		, element(el)
-		{}
+		, element(el) {
+	}
 
-    rack::ui::Menu* createChildMenu() override
-    {
-        auto childMenu = new rack::ui::Menu;
+	rack::ui::Menu *createChildMenu() override {
+		auto childMenu = new rack::ui::Menu;
 
-        for (std::size_t i=0; i<element.num_pos; i++)
-        {
-            auto choiceItem = new AltParamChoiceItem(module, param_idx, element, i + 1);
-            auto choiceText = element.pos_names[i];
-            choiceItem->text = std::string(choiceText);
-            childMenu->addChild(choiceItem);
-        }
-        return childMenu;
-    }
+		for (std::size_t i = 0; i < element.num_pos; i++) {
+			auto choiceItem = new AltParamChoiceItem(module, param_idx, element, i + 1);
+			auto choiceText = element.pos_names[i];
+			choiceItem->text = std::string(choiceText);
+			childMenu->addChild(choiceItem);
+		}
+		return childMenu;
+	}
 
 private:
-    rack::Module* module;
-    std::size_t param_idx;
-    AltParamChoiceLabeled element;
+	rack::Module *module;
+	std::size_t param_idx;
+	AltParamChoiceLabeled element;
 };
 
 /*
  * Slider that snaps to integer values
 */
 
-struct QuantizedSlider : public rack::ui::Slider
-{
-	void onDragMove(const DragMoveEvent& e) override
-	{
+struct QuantizedSlider : public rack::ui::Slider {
+	void onDragMove(const DragMoveEvent &e) override {
 		if (quantity) {
 
 			// This is hardcoded in the rack source code and copied here
@@ -90,8 +84,7 @@ struct QuantizedSlider : public rack::ui::Slider
 			auto quantityIncrement = SENSITIVITY * e.mouseDelta.x;
 			accumulatedDrag += quantityIncrement;
 
-			if (std::abs(accumulatedDrag) >= QuantizationSize)
-			{
+			if (std::abs(accumulatedDrag) >= QuantizationSize) {
 				auto thisDrag = accumulatedDrag > 0 ? QuantizationSize : -QuantizationSize;
 				accumulatedDrag -= thisDrag;
 
@@ -108,18 +101,18 @@ struct QuantizedSlider : public rack::ui::Slider
  * Implementations for rendering the context menu entries for certain alt param elements types
  */
 
-inline void do_render_to_menu(AltParamContinuous el, rack::ui::Menu* menu, Indices &indices, const WidgetContext_t &context)
-{
+inline void
+do_render_to_menu(AltParamContinuous el, rack::ui::Menu *menu, Indices &indices, const WidgetContext_t &context) {
 	auto slider = new rack::ui::Slider;
 	slider->quantity = context.module->getParamQuantity(indices.param_idx);
-	
+
 	// hardcoded slider with according to contained text
 	slider->box.size.x = slider->quantity->getString().size() * 12;
 	menu->addChild(slider);
 }
 
-inline void do_render_to_menu(AltParamChoice el, rack::ui::Menu* menu, Indices &indices, const WidgetContext_t &context)
-{
+inline void
+do_render_to_menu(AltParamChoice el, rack::ui::Menu *menu, Indices &indices, const WidgetContext_t &context) {
 	auto slider = new QuantizedSlider;
 	slider->quantity = context.module->getParamQuantity(indices.param_idx);
 
@@ -128,12 +121,12 @@ inline void do_render_to_menu(AltParamChoice el, rack::ui::Menu* menu, Indices &
 	menu->addChild(slider);
 }
 
-inline void do_render_to_menu(AltParamChoiceLabeled el, rack::ui::Menu* menu, Indices &indices, const WidgetContext_t &context)
-{
+inline void
+do_render_to_menu(AltParamChoiceLabeled el, rack::ui::Menu *menu, Indices &indices, const WidgetContext_t &context) {
 	auto *item = new AltParamChoiceLabledMenu(context.module, indices.param_idx, el);
 	item->text = el.short_name;
-    item->rightText = RIGHT_ARROW;
-    menu->addChild(item);
+	item->rightText = RIGHT_ARROW;
+	menu->addChild(item);
 }
 
-}
+} // namespace MetaModule::VCVImplementation::Widget

--- a/src/widgets/base_modules_implemenation.hh
+++ b/src/widgets/base_modules_implemenation.hh
@@ -51,7 +51,7 @@ inline void do_config_element(AltParamContinuous el, const Indices &indices, con
 }
 
 inline void do_config_element(AltParamChoice el, const Indices &indices, const ModuleContext_t &context) {
-	context.module->configParam(indices.param_idx, 1, el.num_pos, el.DefaultValue, el.short_name.data());
+	context.module->configParam(indices.param_idx, 0, el.num_pos - 1, el.DefaultValue, el.short_name.data());
 }
 
 } // namespace MetaModule::VCVImplementation::Module


### PR DESCRIPTION
Fixes #31 

Also addresses Tapo CV being inverted: https://forum.4ms.info/t/topographic-delay-issues/435/2

And makes the Tapo use less RAM (was 32MB, now is 8MB)