### PR TITLE
Selectively ignore modules when exporting a yml patch file

### DIFF
--- a/src/hub/hub_medium.cc
+++ b/src/hub/hub_medium.cc
@@ -65,7 +65,6 @@ private:
 
 std::string wifiUrl = "";
 Volume wifiVolume = Volume::Card;
-MappingMode hubMappingMode = MappingMode::ALL;
 
 struct HubMediumWidget : MetaModuleHubWidget {
 
@@ -117,12 +116,6 @@ struct HubMediumWidget : MetaModuleHubWidget {
 						 hubModule->wifiPath == "Internal" ? Volume::Internal :
 														 Volume::Card;
 			wifiConnectionText = formatWifiStatus();
-			hubMappingMode = hubModule->mappingMode == "ALL"       ? MappingMode::ALL :
-							 hubModule->mappingMode == "LEFTRIGHT" ? MappingMode::LEFTRIGHT :
-							 hubModule->mappingMode == "RIGHT"     ? MappingMode::RIGHT :
-							 hubModule->mappingMode == "LEFT"      ? MappingMode::LEFT :
-							 										 MappingMode::ALL;
-
 		}
 
 		setPanel(APP->window->loadSvg(asset::plugin(pluginInstance, "res/modules/HubMedium_artwork.svg")));
@@ -265,7 +258,7 @@ struct HubMediumWidget : MetaModuleHubWidget {
 
 		using PatchFileWriter = VCVPatchFileWriter<HubMedium::NumPots, HubMedium::MaxMapsPerPot, MaxKnobSets>;
 		auto yml =
-			PatchFileWriter::createPatchYml(hubModule->id, hubModule->mappings, patchName->text, patchDesc->text, hubMappingMode);
+			PatchFileWriter::createPatchYml(hubModule->id, hubModule->mappings, patchName->text, patchDesc->text, hubModule->mappingMode);
 		PatchFileWriter::writeToFile(patchFileName, yml);
 	}
 
@@ -279,7 +272,7 @@ struct HubMediumWidget : MetaModuleHubWidget {
 
 		using PatchFileWriter = VCVPatchFileWriter<HubMedium::NumPots, HubMedium::MaxMapsPerPot, MaxKnobSets>;
 		auto yml =
-			PatchFileWriter::createPatchYml(hubModule->id, hubModule->mappings, patchName->text, patchDesc->text, hubMappingMode);
+			PatchFileWriter::createPatchYml(hubModule->id, hubModule->mappings, patchName->text, patchDesc->text, hubModule->mappingMode);
 		if (yml.size() > 256 * 1024 && wifiVolume == Volume::Internal) {
 			wifiResponseLabel->showFor(180);
 			wifiResponseLabel->text = "File too large for Internal: max is 256kB";
@@ -341,9 +334,9 @@ struct HubMediumWidget : MetaModuleHubWidget {
 		menu->addChild(createIndexSubmenuItem(
 			"Map modules from:",
 			mappingModeLabels,
-			[]() { return hubMappingMode; },
-			[](size_t index) {
-				hubMappingMode = MappingMode(index);
+			[this]() { return hubModule->mappingMode; },
+			[this](size_t index) {
+				hubModule->setMappingMode(index);
 			}));
 		menu->addChild(new MenuSeparator());
 		menu->addChild(createMenuItem("Set Wi-Fi Expander address", "", [this]() { promptWifiUrl(); }));

--- a/src/hub/hub_module.hh
+++ b/src/hub/hub_module.hh
@@ -143,6 +143,9 @@ struct MetaModuleHubBase : public rack::Module {
 
 			json_t *wifiPathJ = json_string(wifiPath.c_str());
 			json_object_set_new(rootJ, "WifiPath", wifiPathJ);
+
+			json_t *mappingModeJ = json_integer(hubMappingMode);
+			json_object_set_new(rootJ, "MappingMode", mappingModeJ);
 		} else {
 			pr_err("Error: Widget has not been constructed, but dataToJson is being called\n");
 		}
@@ -175,6 +178,10 @@ struct MetaModuleHubBase : public rack::Module {
 		auto wifiPathJ = json_object_get(rootJ, "WifiPath");
 		if (json_is_string(wifiPathJ)) {
 			wifiPath = json_string_value(wifiPathJ);
+		}
+		auto mappingModeJ = json_object_get(rootJ, "MappingMode");
+		if (json_is_integer(mappingModeJ)) {
+			hubMappingMode = MappingMode(json_integer_value(mappingModeJ));
 		}
 
 		mappings.decodeJson(rootJ);

--- a/src/hub/hub_module.hh
+++ b/src/hub/hub_module.hh
@@ -24,12 +24,7 @@ struct MetaModuleHubBase : public rack::Module {
 						   MetaModule::wifiVolume == MetaModule::Volume::USB	  ? "USB" :
 						   MetaModule::wifiVolume == MetaModule::Volume::Internal ? "Internal" :
 																					"Card";
-	std::string mappingMode = MetaModule::hubMappingMode == MetaModule::MappingMode::ALL       ? "ALL" :
-							  MetaModule::hubMappingMode == MetaModule::MappingMode::LEFTRIGHT ? "LEFTRIGHT" :
-							  MetaModule::hubMappingMode == MetaModule::MappingMode::RIGHT     ? "RIGHT" :		
-							  MetaModule::hubMappingMode == MetaModule::MappingMode::LEFT      ? "LEFT" :	
-							  																	 "ALL";
-
+	MappingMode mappingMode = MetaModule::MappingMode::ALL;
 
 	bool should_save = false;
 	bool should_send_wifi = false;
@@ -47,6 +42,18 @@ struct MetaModuleHubBase : public rack::Module {
 
 	void startMappingFrom(int hubParamId) {
 		inProgressMapParamId = hubParamId;
+	}
+
+	std::string mappingModeToString(MetaModule::MappingMode mappingMode) {
+		return mappingMode == MetaModule::MappingMode::ALL       ? "ALL" :
+			   mappingMode == MetaModule::MappingMode::LEFTRIGHT ? "LEFTRIGHT" :
+			   mappingMode == MetaModule::MappingMode::RIGHT     ? "RIGHT" :		
+			   mappingMode == MetaModule::MappingMode::LEFT      ? "LEFT" :	
+							  									   "ALL";
+	}
+
+	void setMappingMode(int index) {
+		mappingMode = MappingMode(index);
 	}
 
 	void endMapping() {
@@ -144,7 +151,7 @@ struct MetaModuleHubBase : public rack::Module {
 			json_t *wifiPathJ = json_string(wifiPath.c_str());
 			json_object_set_new(rootJ, "WifiPath", wifiPathJ);
 
-			json_t *mappingModeJ = json_integer(hubMappingMode);
+			json_t *mappingModeJ = json_integer(this->mappingMode);
 			json_object_set_new(rootJ, "MappingMode", mappingModeJ);
 		} else {
 			pr_err("Error: Widget has not been constructed, but dataToJson is being called\n");
@@ -181,7 +188,7 @@ struct MetaModuleHubBase : public rack::Module {
 		}
 		auto mappingModeJ = json_object_get(rootJ, "MappingMode");
 		if (json_is_integer(mappingModeJ)) {
-			hubMappingMode = MappingMode(json_integer_value(mappingModeJ));
+			mappingMode = MappingMode(json_integer_value(mappingModeJ));
 		}
 
 		mappings.decodeJson(rootJ);
@@ -191,6 +198,7 @@ struct MetaModuleHubBase : public rack::Module {
 		Module::onReset(e);
 		patchNameText = "";
 		patchDescText = "";
+		mappingMode = MetaModule::MappingMode::ALL;
 		mappings.clear_all(ShouldLock::No);
 		mappings.setActiveKnobSetIdx(0);
 		mappings.refreshParamHandles(ShouldLock::No);

--- a/src/hub/hub_module.hh
+++ b/src/hub/hub_module.hh
@@ -24,6 +24,12 @@ struct MetaModuleHubBase : public rack::Module {
 						   MetaModule::wifiVolume == MetaModule::Volume::USB	  ? "USB" :
 						   MetaModule::wifiVolume == MetaModule::Volume::Internal ? "Internal" :
 																					"Card";
+	std::string mappingMode = MetaModule::hubMappingMode == MetaModule::MappingMode::ALL       ? "ALL" :
+							  MetaModule::hubMappingMode == MetaModule::MappingMode::LEFTRIGHT ? "LEFTRIGHT" :
+							  MetaModule::hubMappingMode == MetaModule::MappingMode::RIGHT     ? "RIGHT" :		
+							  MetaModule::hubMappingMode == MetaModule::MappingMode::LEFT      ? "LEFT" :	
+							  																	 "ALL";
+
 
 	bool should_save = false;
 	bool should_send_wifi = false;

--- a/src/mapping/vcv_patch_file_writer.hh
+++ b/src/mapping/vcv_patch_file_writer.hh
@@ -10,20 +10,22 @@
 #include "mapping/module_directory.hh"
 #include "mapping/patch_writer.hh"
 #include "patch/midi_def.hh"
+#include "plugin.hh"
 #include <fstream>
 #include <rack.hpp>
 
 namespace MetaModule
 {
 
-// Adpats VCVRack-format of patch data to a format PatchFileWriter can use
+// Adapts VCVRack-format of patch data to a format PatchFileWriter can use
 template<size_t NumKnobs, size_t MaxMapsPerPot, size_t MaxKnobSets>
 struct VCVPatchFileWriter {
 
 	static std::string createPatchYml(int64_t hubModuleId,
 									  HubKnobMappings<MaxMapsPerPot, MaxKnobSets> &mappings,
 									  std::string patchName,
-									  std::string patchDesc) {
+									  std::string patchDesc,
+									  MappingMode mappingMode) {
 
 		auto context = rack::contextGet();
 		auto engine = context->engine;
@@ -37,33 +39,111 @@ struct VCVPatchFileWriter {
 		MIDI::Modules midimodules;
 		ExpanderMappings expanders;
 
-		auto moduleIDs = engine->getModuleIds();
-		for (auto moduleID : moduleIDs) {
+		if (mappingMode == MappingMode::ALL) {
+			auto moduleIDs = engine->getModuleIds();
+			for (auto moduleID : moduleIDs) {
 
-			auto *module = engine->getModule(moduleID);
+				auto *module = engine->getModule(moduleID);
 
-			if (ModuleDirectory::isRegularModule(module) || ModuleDirectory::isHub(module)) {
-				auto brand_module = ModuleDirectory::convertSlugs(module);
-				auto moduleWidget = APP->scene->rack->getModule(moduleID);
-				if (moduleWidget) {
-					moduleData.push_back({moduleID,
-										  brand_module.c_str(),
-										  moduleWidget->getBox().getLeft(),
-										  moduleWidget->getBox().getTop()});
-					if (module->model->slug.size() > 31) {
-						pr_warn("Warning: module slug truncated to 31 chars\n");
+				if (ModuleDirectory::isRegularModule(module) || ModuleDirectory::isHub(module)) {
+					auto brand_module = ModuleDirectory::convertSlugs(module);
+					auto moduleWidget = APP->scene->rack->getModule(moduleID);
+					if (moduleWidget) {
+						moduleData.push_back({moduleID,
+											  brand_module.c_str(),
+											  moduleWidget->getBox().getLeft(),
+											  moduleWidget->getBox().getTop()});
+						if (module->model->slug.size() > 31) {
+							pr_warn("Warning: module slug truncated to 31 chars\n");
+						}
+					}
+
+					if (!ModuleDirectory::isHubOrExpander(module)) {
+						for (size_t i = 0; i < module->paramQuantities.size(); i++) {
+							float val = module->getParamQuantity(i)->getScaledValue();
+							paramData.push_back({.value = val, .paramID = (int)i, .moduleID = moduleID});
+						}
 					}
 				}
-
-				if (!ModuleDirectory::isHubOrExpander(module)) {
-					for (size_t i = 0; i < module->paramQuantities.size(); i++) {
-						float val = module->getParamQuantity(i)->getScaledValue();
-						paramData.push_back({.value = val, .paramID = (int)i, .moduleID = moduleID});
-					}
-				}
+				midimodules.addMidiModule(module);
+				expanders.addModule(module);
 			}
-			midimodules.addMidiModule(module);
-			expanders.addModule(module);
+		}
+		
+		bool mappedHubModule = false;
+		if (mappingMode == MappingMode::LEFTRIGHT || mappingMode == MappingMode::LEFT) {
+
+			// Add modules joined to the left of the hub module
+			auto* module = engine->getModule(hubModuleId);
+			while (true) {
+				if (!module) break;
+
+				int64_t moduleID = module->getId();
+				if (ModuleDirectory::isRegularModule(module) || ModuleDirectory::isHub(module)) {
+					auto brand_module = ModuleDirectory::convertSlugs(module);
+					auto moduleWidget = APP->scene->rack->getModule(moduleID);
+					if (moduleWidget) {
+						moduleData.push_back({moduleID,
+											  brand_module.c_str(),
+											  moduleWidget->getBox().getLeft(),
+											  moduleWidget->getBox().getTop()});
+						if (module->model->slug.size() > 31) {
+							pr_warn("Warning: module slug truncated to 31 chars\n");
+						}
+						mappedHubModule = ModuleDirectory::isHub(module);
+					}
+
+					if (!ModuleDirectory::isHubOrExpander(module)) {
+						for (size_t i = 0; i < module->paramQuantities.size(); i++) {
+							float val = module->getParamQuantity(i)->getScaledValue();
+							paramData.push_back({.value = val, .paramID = (int)i, .moduleID = moduleID});
+						}
+					}
+				}
+				midimodules.addMidiModule(module);
+				expanders.addModule(module);
+
+				if (module->leftExpander.moduleId < 0) break;
+				if (!module->leftExpander.module) break;
+				module = module->leftExpander.module;
+			}
+		}
+
+		if (mappingMode == MappingMode::LEFTRIGHT || mappingMode == MappingMode::RIGHT) {
+
+			// Add modules joined to the right of the hub module
+			auto* module = engine->getModule(hubModuleId);
+			while (true) {
+				if (!module) break;
+
+				int64_t moduleID = module->getId();
+				if (ModuleDirectory::isRegularModule(module) || (!mappedHubModule && ModuleDirectory::isHub(module))) {
+					auto brand_module = ModuleDirectory::convertSlugs(module);
+					auto moduleWidget = APP->scene->rack->getModule(moduleID);
+					if (moduleWidget) {
+						moduleData.push_back({moduleID,
+											  brand_module.c_str(),
+											  moduleWidget->getBox().getLeft(),
+											  moduleWidget->getBox().getTop()});
+						if (module->model->slug.size() > 31) {
+							pr_warn("Warning: module slug truncated to 31 chars\n");
+						}
+					}
+
+					if (!ModuleDirectory::isHubOrExpander(module)) {
+						for (size_t i = 0; i < module->paramQuantities.size(); i++) {
+							float val = module->getParamQuantity(i)->getScaledValue();
+							paramData.push_back({.value = val, .paramID = (int)i, .moduleID = moduleID});
+						}
+					}
+				}
+				midimodules.addMidiModule(module);
+				expanders.addModule(module);
+
+				if (module->rightExpander.moduleId < 0) break;
+				if (!module->rightExpander.module) break;
+				module = module->rightExpander.module;
+			}
 		}
 
 		// Scan cables for MIDICV -> Split connections

--- a/src/plugin.hh
+++ b/src/plugin.hh
@@ -7,7 +7,10 @@ namespace MetaModule
 
 extern std::string wifiUrl;
 enum Volume { Internal = 0, USB = 1, Card = 2 };
+enum MappingMode { ALL = 0, LEFTRIGHT = 1, RIGHT = 2, LEFT = 3 };
+
 extern Volume wifiVolume;
+extern MappingMode hubMappingMode;
 
 } // namespace MetaModule
 

--- a/src/plugin.hh
+++ b/src/plugin.hh
@@ -10,7 +10,6 @@ enum Volume { Internal = 0, USB = 1, Card = 2 };
 enum MappingMode { ALL = 0, LEFTRIGHT = 1, RIGHT = 2, LEFT = 3 };
 
 extern Volume wifiVolume;
-extern MappingMode hubMappingMode;
 
 } // namespace MetaModule
 


### PR DESCRIPTION
This is a PR to add the capability of alternative module export selection methods in the MetaModule Hub module.  See [original Forum thread here](https://forum.4ms.info/t/selectively-ignore-modules-in-vcvrack-when-exporting-a-yml-patch-file/1489).

As a side benefit, this also now supports having multiple Hub modules in one VCVRack patch, each exporting a different chain of modules (e.g. for multiple hardware MetaModules or switching between multiple variants of the same MM patch during the patching phase).

<img width="1358" alt="image" src="https://github.com/user-attachments/assets/bb5d1d43-a24f-48e3-bde8-ab5f012c231f" />


**Proposed Solution**

Introduce a new Hub module context menu option to select which module selection algorithm to use:

<img width="386" alt="image" src="https://github.com/user-attachments/assets/43e16dca-c108-4145-93f1-3a5cdfa529de" />

| Option | Algorithm |
| ------ | --------- |
| **ALL** (default) - 0 | Export all modules in the current VCVRack patch (existing behaviour) |
| **LEFTRIGHT** - 1| Only export modules attached (positioned next to without gaps) to the left or right of the hub module on the same row |
| **RIGHT** - 2|  Only export modules attached (positioned next to without gaps) to the right of the hub module on the same row |
| **LEFT** - 3|  Only export modules attached (positioned next to without gaps) to the left of the hub module on the same row |

This PR code adds a new module instance - specific `MappingMode` enum index property to the hub module persisted state.

```
    ...
    "PatchName": "Enter Patch Name",
    "PatchDesc": "Patch Description",
    "DefaultKnobSet": 0,
    "WifiURL": "http://192.168.1.230",
    "WifiPath": "Card",
    "MappingMode": 1
    ...
```

**Implementation Notes**

The new module selection algorithms exploit the same VCVRack module expander navigation API that is used in the well-established [Stoermelder Strip](https://library.vcvrack.com/Stoermelder-P1/Strip) module: https://github.com/stoermelder/vcvrack-packone/blob/v2/src/Strip.cpp#L179-L199



