### PR TITLE
Add option to include only connected modules to the patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGE LOG
 
+## v2.0.15 (in progress)
+
+- Add "Include Modules from:" right-click menu option that allows including only certain modules in the exported patch file. 
+  Thanks to @rjsmith.
+   - All: include all modules (current behavior)
+   - Left Only: only modules touching each other to the left of the Hub
+   - Right Only: only modules touching each other to the right of the Hub
+   - Left & Right Only: only modules touching each other to the left or the right of the Hub
+   - Connected: only modules connected to the Hub by cables, directly or indirectly through any number of other modules.
+
+- Fix Wi-Fi URL being stored in patch file and overriding local settings
+
 ## v2.0.14
 
 - Knob alias name is removed if knob no longer has any mappings

--- a/plugin.json
+++ b/plugin.json
@@ -1,14 +1,14 @@
 {
   "slug": "4msCompany",
   "name": "4ms",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "license": "GPL-3.0-or-later",
   "brand": "4ms",
   "author": "4ms Company",
   "authorEmail": "4ms@4mscompany.com",
   "authorUrl": "https://4mscompany.com",
   "pluginUrl": "https://github.com/4ms/4ms-vcv/",
-  "manualUrl": "https://metamodule.info/docs",
+  "manualUrl": "https://metamodule.info/docs/using_rack.html",
   "sourceUrl": "https://github.com/4ms/4ms-vcv/",
   "donateUrl": "",
   "changelogUrl": "https://github.com/4ms/4ms-vcv/blob/main/CHANGELOG.md",
@@ -18,7 +18,7 @@
       "name": "MetaModule",
       "description": "MetaModule Hub is used to create patches that run on MetaModule hardware. Use the hub to create mappings between physical and virtual controls and jacks.",
       "modularGridUrl": "https://modulargrid.net/e/4ms-company-metamodule",
-      "manualUrl": "https://4mscompany.com/metamodule",
+      "manualUrl": "https://metamodule.info/docs/using_rack.html",
       "tags": ["Utility", "External"]
     },
     {
@@ -332,8 +332,8 @@
       "slug": "MMAudioExpander",
       "name": "MetaModule Audio Expander (MM AIO)",
       "description": "Expander that adds 6 audio/cv inputs and 8 audio/cv outputs to the MetaModule",
-      "modularGridUrl": "https://modulargrid.net/e/4ms-company-metamodule",
-      "manualUrl": "https://metamodule.4ms.info",
+      "modularGridUrl": "https://modulargrid.net/e/4ms-company-metaaio",
+      "manualUrl": "https://4mscompany.com/media/MetaModule/MetaAIO-Quick-Start.pdf",
       "tags": ["Expander", "External"]
     }
   ]

--- a/src/hub/hub_medium.cc
+++ b/src/hub/hub_medium.cc
@@ -91,7 +91,8 @@ struct HubMediumWidget : MetaModuleHubWidget {
 	std::string wifiConnectionText;
 
 	const std::vector<std::string> volumeLabels = {"Internal", "USB", "Card"};
-	const std::vector<std::string> mappingModeLabels = {"All", "Left & Right Only", "Right Only", "Left Only"};
+	const std::vector<std::string> mappingModeLabels = {
+		"All", "Left & Right Only", "Right Only", "Left Only", "Connected"};
 
 	HubMediumWidget(HubMedium *module) {
 		setModule(module);
@@ -321,7 +322,7 @@ struct HubMediumWidget : MetaModuleHubWidget {
 		using namespace rack;
 		menu->addChild(new MenuSeparator());
 		menu->addChild(createIndexSubmenuItem(
-			"Map modules from:",
+			"Include modules from:",
 			mappingModeLabels,
 			[this]() { return hubModule->mappingMode; },
 			[this](size_t index) { hubModule->setMappingMode(index); }));

--- a/src/mapping/vcv_patch_file_writer.hh
+++ b/src/mapping/vcv_patch_file_writer.hh
@@ -54,6 +54,40 @@ struct VCVPatchFileWriter {
 			}
 		}
 
+		if (mappingMode == MappingMode::CONNECTED) {
+			std::set<int64_t> connected_modules;
+			connected_modules.insert(hubModuleId);
+
+			auto cables = engine->getCableIds();
+
+			unsigned num_found = 0;
+
+			// iterate all cables until we find no more new modules
+			while (connected_modules.size() != num_found) {
+
+				num_found = connected_modules.size();
+
+				for (auto cable_id : cables) {
+					auto *cable = engine->getCable(cable_id);
+					if (cable->inputModule && cable->outputModule) {
+						auto input_id = cable->inputModule->getId();
+						auto output_id = cable->outputModule->getId();
+
+						if (connected_modules.contains(input_id)) {
+							connected_modules.insert(output_id);
+						} else if (connected_modules.contains(output_id)) {
+							connected_modules.insert(input_id);
+						}
+					}
+				}
+			}
+
+			for (auto module_id : connected_modules) {
+				if (auto *module = engine->getModule(module_id))
+					addModuleToMapping(module, moduleData, paramData, midimodules, expanders);
+			}
+		}
+
 		if (mappingMode == MappingMode::LEFTRIGHT || mappingMode == MappingMode::LEFT) {
 
 			// Add modules joined to the left of the hub module

--- a/src/mapping/vcv_patch_file_writer.hh
+++ b/src/mapping/vcv_patch_file_writer.hh
@@ -92,15 +92,12 @@ struct VCVPatchFileWriter {
 
 			// Add modules joined to the left of the hub module
 			auto *module = engine->getModule(hubModuleId);
-			while (true) {
-				if (!module)
-					break;
+			while (module) {
 				addModuleToMapping(module, moduleData, paramData, midimodules, expanders);
 
 				if (module->leftExpander.moduleId < 0)
 					break;
-				if (!module->leftExpander.module)
-					break;
+
 				module = module->leftExpander.module;
 			}
 		}
@@ -109,15 +106,12 @@ struct VCVPatchFileWriter {
 
 			// Add modules joined to the right of the hub module
 			auto *module = engine->getModule(hubModuleId);
-			while (true) {
-				if (!module)
-					break;
+			while (module) {
 				addModuleToMapping(module, moduleData, paramData, midimodules, expanders);
 
 				if (module->rightExpander.moduleId < 0)
 					break;
-				if (!module->rightExpander.module)
-					break;
+
 				module = module->rightExpander.module;
 			}
 		}

--- a/src/plugin.hh
+++ b/src/plugin.hh
@@ -6,7 +6,7 @@ namespace MetaModule
 
 extern std::string wifiUrl;
 enum Volume { Internal = 0, USB = 1, Card = 2 };
-enum MappingMode { ALL = 0, LEFTRIGHT = 1, RIGHT = 2, LEFT = 3 };
+enum MappingMode { ALL = 0, LEFTRIGHT = 1, RIGHT = 2, LEFT = 3, CONNECTED = 4 };
 
 extern Volume wifiVolume;
 


### PR DESCRIPTION
This adds a fourth option to the "Include modules from" right-click menu option created by #39 .
This "Connected" option adds only module that are connected via cables to the hub, directly or indirectly (e.g. through any number of other modules).