### PR TITLE
Export module bypass state to patch YAML

### DIFF
--- a/src/mapping/patch_writer.cc
+++ b/src/mapping/patch_writer.cc
@@ -271,6 +271,14 @@ void PatchFileWriter::addModuleStateJson(rack::Module *module) {
 	}
 }
 
+void PatchFileWriter::addBypassedModule(rack::Module *module) {
+	if (!module || !module->isBypassed())
+		return;
+	if (!idMap.contains(module->id))
+		return;
+	pd.bypassed_modules.push_back(idMap[module->id]);
+}
+
 void PatchFileWriter::addKnobMapSet(unsigned knobSetId, std::string_view knobSetName) {
 	if (knobSetId >= pd.knob_sets.size())
 		pd.knob_sets.resize(knobSetId + 1);

--- a/src/mapping/patch_writer.hh
+++ b/src/mapping/patch_writer.hh
@@ -28,6 +28,7 @@ public:
 	void setMidiSettings(MIDI::Settings const &settings);
 	void setExpanders(ExpanderMappings const &exp);
 	void addModuleStateJson(rack::Module *module);
+	void addBypassedModule(rack::Module *module);
 
 	void setSuggestedSamplerateBlocksize(unsigned sample_rate, unsigned blocksize);
 

--- a/src/mapping/vcv_patch_file_writer.hh
+++ b/src/mapping/vcv_patch_file_writer.hh
@@ -206,10 +206,12 @@ struct VCVPatchFileWriter {
 		pw.setJackAliases(aliases);
 
 		// Add module state from Module::dataToJson()
+		// Add bypass state from Module::isBypassed()
 		for (auto moduleID : engine->getModuleIds()) {
 			auto *module = engine->getModule(moduleID);
 			if (ModuleDirectory::isRegularModule(module)) {
 				pw.addModuleStateJson(module);
+				pw.addBypassedModule(module);
 			}
 		}
 


### PR DESCRIPTION
## Summary

When exporting a VCV Rack patch to MetaModule format, bypassed modules are now recorded in the patch YAML. This is the companion change to [4ms/metamodule#552](https://github.com/4ms/metamodule/pull/552), which adds bypass support to the MetaModule firmware.

`PatchFileWriter::addBypassedModule()` checks `module->isBypassed()`, maps the VCV module ID to the MetaModule ID via `idMap`, and appends it to `pd.bypassed_modules`. Called alongside `addModuleStateJson()` in the existing module loop in `VCVPatchFileWriter`.