### PR TITLE
Export module bypass state when saving patches

### DIFF
--- a/src/mapping/patch_writer.cc
+++ b/src/mapping/patch_writer.cc
@@ -271,6 +271,14 @@ void PatchFileWriter::addModuleStateJson(rack::Module *module) {
 	}
 }
 
+void PatchFileWriter::addBypassedModule(rack::Module *module) {
+	if (!module || !module->isBypassed())
+		return;
+	if (!idMap.contains(module->id))
+		return;
+	pd.bypassed_modules.push_back(idMap[module->id]);
+}
+
 void PatchFileWriter::addKnobMapSet(unsigned knobSetId, std::string_view knobSetName) {
 	if (knobSetId >= pd.knob_sets.size())
 		pd.knob_sets.resize(knobSetId + 1);

--- a/src/mapping/patch_writer.hh
+++ b/src/mapping/patch_writer.hh
@@ -28,6 +28,7 @@ public:
 	void setMidiSettings(MIDI::Settings const &settings);
 	void setExpanders(ExpanderMappings const &exp);
 	void addModuleStateJson(rack::Module *module);
+	void addBypassedModule(rack::Module *module);
 
 	void setSuggestedSamplerateBlocksize(unsigned sample_rate, unsigned blocksize);
 

--- a/src/mapping/vcv_patch_file_writer.hh
+++ b/src/mapping/vcv_patch_file_writer.hh
@@ -206,10 +206,12 @@ struct VCVPatchFileWriter {
 		pw.setJackAliases(aliases);
 
 		// Add module state from Module::dataToJson()
+		// Add bypass state from Module::isBypassed()
 		for (auto moduleID : engine->getModuleIds()) {
 			auto *module = engine->getModule(moduleID);
 			if (ModuleDirectory::isRegularModule(module)) {
 				pw.addModuleStateJson(module);
+				pw.addBypassedModule(module);
 			}
 		}
 


### PR DESCRIPTION
## Summary

- When exporting a patch from VCV Rack to MetaModule format, write the bypass state of each module using `PatchFileWriter::addBypassedModule()`
- Reads `module->isBypassed()` and maps VCV module IDs to MetaModule IDs via `idMap`

Depends on 4ms/metamodule-patch-serial#1 (for `addBypassedModule` and `bypassed_modules` field).

## Test plan

- [ ] In VCV Rack, bypass a module, export patch to MetaModule format — verify the YAML contains `bypassed_modules` with the correct module ID
- [ ] Export a patch with no bypassed modules — verify `bypassed_modules` is empty or absent
- [ ] Load the exported patch on MetaModule (or simulator) — bypassed modules should appear dimmed and audio output should change depending on that module's bypass settings