### PR TITLE
Enable line breaks in patch description text field

### DIFF
--- a/src/hub/hub_medium.cc
+++ b/src/hub/hub_medium.cc
@@ -140,6 +140,7 @@ struct HubMediumWidget : MetaModuleHubWidget {
 		patchDesc->placeholder = "Patch Description";
 		patchDesc->color = rack::color::BLACK;
 		patchDesc->box.size = {rack::mm2px(rack::math::Vec(57.7f, 31.3f))};
+		patchDesc->multiline = true;
 		patchDesc->cursor = 0;
 		// addChild(patchDesc);
 


### PR DESCRIPTION
One-liner that addresses this request: https://forum.4ms.info/t/line-breaks-in-patch-description-field/443. Tested on macOS and Windows — line breaks are properly serialized and propagate to Meta.