### PR TITLE
Poly midi cable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v2.1.9 (in progress)
 - Add context-menu option to automatically map the source of AudioInterface module inputs to unmapped Panel Outs
 - Do not add Stoermelder Glue module to patch files
+- Always convert MIDI-Map module CC mappings into the patch's MIDI map (even when "Use RackCore MIDI" is selected), and never add the MIDI-Map module itself to the patch
 
 ## v2.1.8
 - Add support for summed input jacks on the Hub panel (i.e. patching multiple module output jacks to a Hub "Out" jack)

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "slug": "4msCompany",
   "name": "4ms",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "license": "GPL-3.0-or-later",
   "brand": "4ms",
   "author": "4ms Company",

--- a/src/hub/hub_medium.cc
+++ b/src/hub/hub_medium.cc
@@ -280,7 +280,8 @@ struct HubMediumWidget : MetaModuleHubWidget {
 													hubModule->blockSizeNums[hubModule->suggested_blocksize_idx],
 													hubModule->use_glue_labels,
 													hubModule->use_builtin_midi,
-													hubModule->module_aliases});
+													hubModule->module_aliases,
+													hubModule->auto_map_audio_outs});
 		PatchFileWriter::writeToFile(patchFileName, yml);
 	}
 
@@ -303,7 +304,8 @@ struct HubMediumWidget : MetaModuleHubWidget {
 													hubModule->blockSizeNums[hubModule->suggested_blocksize_idx],
 													hubModule->use_glue_labels,
 													hubModule->use_builtin_midi,
-													hubModule->module_aliases});
+													hubModule->module_aliases,
+													hubModule->auto_map_audio_outs});
 		if (yml.size() > 256 * 1024 && wifiVolume == Volume::Internal) {
 			wifiResponseLabel->showFor(180);
 			wifiResponseLabel->text = "File too large for Internal: max is 256kB";
@@ -565,6 +567,12 @@ struct HubMediumWidget : MetaModuleHubWidget {
 			"",
 			[this]() { return !hubModule->use_builtin_midi; },
 			[this]() { hubModule->use_builtin_midi = false; }));
+		menu->addChild(new MenuSeparator());
+		menu->addChild(createCheckMenuItem(
+			"Automatically map AudioInterface to panel outs",
+			"",
+			[this]() { return hubModule->auto_map_audio_outs; },
+			[this]() { hubModule->auto_map_audio_outs = !hubModule->auto_map_audio_outs; }));
 		menu->addChild(new MenuSeparator());
 	}
 

--- a/src/hub/hub_medium.cc
+++ b/src/hub/hub_medium.cc
@@ -279,6 +279,7 @@ struct HubMediumWidget : MetaModuleHubWidget {
 													hubModule->sampleRateNums[hubModule->suggested_samplerate_idx],
 													hubModule->blockSizeNums[hubModule->suggested_blocksize_idx],
 													hubModule->use_glue_labels,
+													hubModule->use_builtin_midi,
 													hubModule->module_aliases});
 		PatchFileWriter::writeToFile(patchFileName, yml);
 	}
@@ -301,6 +302,7 @@ struct HubMediumWidget : MetaModuleHubWidget {
 													hubModule->sampleRateNums[hubModule->suggested_samplerate_idx],
 													hubModule->blockSizeNums[hubModule->suggested_blocksize_idx],
 													hubModule->use_glue_labels,
+													hubModule->use_builtin_midi,
 													hubModule->module_aliases});
 		if (yml.size() > 256 * 1024 && wifiVolume == Volume::Internal) {
 			wifiResponseLabel->showFor(180);

--- a/src/hub/hub_medium.cc
+++ b/src/hub/hub_medium.cc
@@ -551,6 +551,19 @@ struct HubMediumWidget : MetaModuleHubWidget {
 			[this]() { return hubModule->suggested_blocksize_idx; },
 			[this](int idx) { hubModule->suggested_blocksize_idx = idx; });
 		menu->addChild(sugg_blocksize);
+
+		menu->addChild(new MenuSeparator());
+		menu->addChild(createCheckMenuItem(
+			"Use built-in MIDI",
+			"",
+			[this]() { return hubModule->use_builtin_midi; },
+			[this]() { hubModule->use_builtin_midi = true; }));
+		menu->addChild(createCheckMenuItem(
+			"Use RackCore MIDI",
+			"",
+			[this]() { return !hubModule->use_builtin_midi; },
+			[this]() { hubModule->use_builtin_midi = false; }));
+		menu->addChild(new MenuSeparator());
 	}
 
 	std::string formatWifiStatus() {

--- a/src/hub/hub_medium.cc
+++ b/src/hub/hub_medium.cc
@@ -426,7 +426,7 @@ struct HubMediumWidget : MetaModuleHubWidget {
 			std::vector<ModuleEntry> entries;
 
 			auto addIfRegular = [&](rack::Module *module) {
-				if (!ModuleDirectory::isRegularModule(module))
+				if (!ModuleDirectory::isRegularModule(module, hubModule->use_builtin_midi))
 					return;
 				auto *mw = APP->scene->rack->getModule(module->getId());
 				if (mw)

--- a/src/hub/hub_module.hh
+++ b/src/hub/hub_module.hh
@@ -39,6 +39,7 @@ struct MetaModuleHubBase : public rack::Module {
 	JackAlias jack_alias{};
 
 	bool use_glue_labels = true;
+	bool use_builtin_midi = true;
 	std::map<int64_t, std::string> module_aliases;
 	std::map<int64_t, int> module_alias_colors;
 
@@ -190,6 +191,7 @@ struct MetaModuleHubBase : public rack::Module {
 		json_object_set_new(rootJ, "DefaultKnobSet", defaultKnobSetJ);
 
 		json_object_set_new(rootJ, "UseGlueLabels", json_boolean(use_glue_labels));
+		json_object_set_new(rootJ, "UseBuiltinMidi", json_boolean(use_builtin_midi));
 
 		json_t *moduleAliasesJ = json_object();
 		for (auto const &[id, alias] : module_aliases)
@@ -254,6 +256,10 @@ struct MetaModuleHubBase : public rack::Module {
 		if (json_is_boolean(useGlueLabelsJ))
 			use_glue_labels = json_boolean_value(useGlueLabelsJ);
 
+		auto useBuiltinMidiJ = json_object_get(rootJ, "UseBuiltinMidi");
+		if (json_is_boolean(useBuiltinMidiJ))
+			use_builtin_midi = json_boolean_value(useBuiltinMidiJ);
+
 		auto moduleAliasesJ = json_object_get(rootJ, "ModuleAliases");
 		if (json_is_object(moduleAliasesJ)) {
 			module_aliases.clear();
@@ -287,6 +293,7 @@ struct MetaModuleHubBase : public rack::Module {
 		patchDescText = "";
 		mappingMode = MetaModule::MappingMode::ALL;
 		use_glue_labels = true;
+		use_builtin_midi = true;
 		module_aliases.clear();
 		module_alias_colors.clear();
 		mappings.clear_all(ShouldLock::No);

--- a/src/hub/hub_module.hh
+++ b/src/hub/hub_module.hh
@@ -40,6 +40,7 @@ struct MetaModuleHubBase : public rack::Module {
 
 	bool use_glue_labels = true;
 	bool use_builtin_midi = true;
+	bool auto_map_audio_outs = false;
 	std::map<int64_t, std::string> module_aliases;
 	std::map<int64_t, int> module_alias_colors;
 
@@ -192,6 +193,7 @@ struct MetaModuleHubBase : public rack::Module {
 
 		json_object_set_new(rootJ, "UseGlueLabels", json_boolean(use_glue_labels));
 		json_object_set_new(rootJ, "UseBuiltinMidi", json_boolean(use_builtin_midi));
+		json_object_set_new(rootJ, "AutoMapAudioOuts", json_boolean(auto_map_audio_outs));
 
 		json_t *moduleAliasesJ = json_object();
 		for (auto const &[id, alias] : module_aliases)
@@ -260,6 +262,10 @@ struct MetaModuleHubBase : public rack::Module {
 		if (json_is_boolean(useBuiltinMidiJ))
 			use_builtin_midi = json_boolean_value(useBuiltinMidiJ);
 
+		auto autoMapAudioOutsJ = json_object_get(rootJ, "AutoMapAudioOuts");
+		if (json_is_boolean(autoMapAudioOutsJ))
+			auto_map_audio_outs = json_boolean_value(autoMapAudioOutsJ);
+
 		auto moduleAliasesJ = json_object_get(rootJ, "ModuleAliases");
 		if (json_is_object(moduleAliasesJ)) {
 			module_aliases.clear();
@@ -294,6 +300,7 @@ struct MetaModuleHubBase : public rack::Module {
 		mappingMode = MetaModule::MappingMode::ALL;
 		use_glue_labels = true;
 		use_builtin_midi = true;
+		auto_map_audio_outs = false;
 		module_aliases.clear();
 		module_alias_colors.clear();
 		mappings.clear_all(ShouldLock::No);

--- a/src/mapping/midi_modules.cc
+++ b/src/mapping/midi_modules.cc
@@ -59,8 +59,10 @@ void Modules::addPolySplitCable(rack::Cable *cable) {
 }
 
 bool Modules::isPolySplitModule(rack::Module *module) {
-	auto id = module->getId();
+	return isPolySplitModule(module->getId());
+}
 
+bool Modules::isPolySplitModule(int64_t id) {
 	for (auto const &midicv_module : settings.CV) {
 		if ((id == midicv_module.voctSplitModuleId) || (id == midicv_module.gateSplitModuleId) ||
 			(id == midicv_module.velSplitModuleId) || (id == midicv_module.aftSplitModuleId) ||

--- a/src/mapping/midi_modules.hh
+++ b/src/mapping/midi_modules.hh
@@ -80,6 +80,7 @@ struct Modules {
 	void addMidiModule(rack::Module *module);
 	void addPolySplitCable(rack::Cable *cable);
 	bool isPolySplitModule(rack::Module *module);
+	bool isPolySplitModule(int64_t module_id);
 };
 
 } // namespace MetaModule::MIDI

--- a/src/mapping/module_directory.hh
+++ b/src/mapping/module_directory.hh
@@ -137,6 +137,20 @@ struct ModuleDirectory {
 
 	// MIDI
 
+	static bool isCoreSplitMerge(rack::Module *module) {
+		if (!isValid(module))
+			return false;
+
+		if (module->model->plugin->slug == "Core") {
+			if (module->model->slug == "Split")
+				return true;
+			if (module->model->slug == "Merge")
+				return true;
+		}
+
+		return false;
+	}
+
 	static bool isCoreMIDI(rack::Module *module) {
 		if (!isValid(module))
 			return false;

--- a/src/mapping/module_directory.hh
+++ b/src/mapping/module_directory.hh
@@ -16,9 +16,11 @@ struct ModuleDirectory {
 		if (isHubOrExpander(module))
 			return false;
 
-		// When using RackCore MIDI, treat Split, Merge, and Core::MIDI* modules as normal regular modules
+		// When using RackCore MIDI, treat Core::MIDI* modules as normal regular modules
+		// (Split and Merge are always regular modules; poly-split Splits are filtered later
+		// using MIDI::Modules::isPolySplitModule in built-in MIDI mode.)
 		if (!use_builtin_midi) {
-			if (isCoreSplitMerge(module) || isCoreMIDI(module))
+			if (isCoreMIDI(module))
 				return true;
 		}
 
@@ -33,9 +35,7 @@ struct ModuleDirectory {
 								"MIDIToCVInterface",
 								"MIDI-Map",
 								"MIDITriggerToCVInterface",
-								"MIDICCToCVInterface",
-								"Split",
-								"Merge"};
+								"MIDICCToCVInterface"};
 
 		for (auto slug : blacklist) {
 			if (module->model->slug == slug)

--- a/src/mapping/module_directory.hh
+++ b/src/mapping/module_directory.hh
@@ -9,12 +9,18 @@ struct ModuleDirectory {
 	// We exclude modules which users would not expect to have
 	// running on hardware, like modules that do MIDI Mappings,
 	// notes, blanks, scope modules, etc.
-	static bool isRegularModule(rack::Module *module) {
+	static bool isRegularModule(rack::Module *module, bool use_builtin_midi) {
 		if (!isValid(module))
 			return false;
 
 		if (isHubOrExpander(module))
 			return false;
+
+		// When using RackCore MIDI, treat Split, Merge, and Core::MIDI* modules as normal regular modules
+		if (!use_builtin_midi) {
+			if (isCoreSplitMerge(module) || isCoreMIDI(module))
+				return true;
+		}
 
 		std::array blacklist = {"AudioInterface2",
 								"AudioInterface",
@@ -29,9 +35,7 @@ struct ModuleDirectory {
 								"MIDITriggerToCVInterface",
 								"MIDICCToCVInterface",
 								"Split",
-								"Merge"
-
-		};
+								"Merge"};
 
 		for (auto slug : blacklist) {
 			if (module->model->slug == slug)

--- a/src/mapping/module_directory.hh
+++ b/src/mapping/module_directory.hh
@@ -155,6 +155,17 @@ struct ModuleDirectory {
 		return false;
 	}
 
+	static bool isAudioInterface(rack::Module *module) {
+		if (!isValid(module))
+			return false;
+
+		if (module->model->plugin->slug != "Core")
+			return false;
+
+		auto const &slug = module->model->slug;
+		return slug == "AudioInterface" || slug == "AudioInterface2" || slug == "AudioInterface16";
+	}
+
 	static bool isCoreMIDI(rack::Module *module) {
 		if (!isValid(module))
 			return false;

--- a/src/mapping/module_directory.hh
+++ b/src/mapping/module_directory.hh
@@ -19,8 +19,10 @@ struct ModuleDirectory {
 		// When using RackCore MIDI, treat Core::MIDI* modules as normal regular modules
 		// (Split and Merge are always regular modules; poly-split Splits are filtered later
 		// using MIDI::Modules::isPolySplitModule in built-in MIDI mode.)
+		// MIDI-Map is the exception: its CC mappings are always converted into the patch's
+		// MIDI map and the module itself is never added (in either MIDI mode).
 		if (!use_builtin_midi) {
-			if (isCoreMIDI(module))
+			if (isCoreMIDI(module) && !isMidiMap(module))
 				return true;
 		}
 
@@ -182,6 +184,13 @@ struct ModuleDirectory {
 		}
 
 		return false;
+	}
+
+	static bool isMidiMap(rack::Module *module) {
+		if (!isValid(module))
+			return false;
+
+		return module->model->plugin->slug == "Core" && module->model->slug == "MIDI-Map";
 	}
 
 	static bool isValid(rack::Module *module) {

--- a/src/mapping/patch_writer.cc
+++ b/src/mapping/patch_writer.cc
@@ -132,7 +132,18 @@ void PatchFileWriter::setCableList(std::vector<CableMap> &cables) {
 				handled = true;
 
 			} else if (cable.outputModuleId == cv_module.module_id) {
-				mapMidiCVJack(cable, cv_module.midi_chan);
+				// Check if cable goes to a Split module (handled by split path above)
+				bool goesToSplit = (cable.inputModuleId == cv_module.voctSplitModuleId ||
+								   cable.inputModuleId == cv_module.gateSplitModuleId ||
+								   cable.inputModuleId == cv_module.velSplitModuleId ||
+								   cable.inputModuleId == cv_module.aftSplitModuleId ||
+								   cable.inputModuleId == cv_module.retrigSplitModuleId);
+				if (goesToSplit) {
+					// MIDICV→Split cable: skip, outputs from Split are handled above
+				} else {
+					// Direct MIDICV→virtual module: use poly mapping for poly-capable jacks
+					mapMidiCVPolyJack(cable, cv_module.midi_chan);
+				}
 				handled = true;
 			}
 		}
@@ -380,6 +391,34 @@ void PatchFileWriter::mapOutputJack(CableMap &map) {
 			.alias_name = "",
 		});
 	}
+}
+
+void PatchFileWriter::mapMidiCVPolyJack(CableMap &cable, uint32_t midi_chan) {
+	using enum MIDI::CoreMidiJacks;
+
+	if (cable.outputJackId == VoctJack)
+		cable.outputJackId = MidiNotePolyJack;
+
+	else if (cable.outputJackId == GateJack)
+		cable.outputJackId = MidiGatePolyJack;
+
+	else if (cable.outputJackId == VelJack)
+		cable.outputJackId = MidiVelPolyJack;
+
+	else if (cable.outputJackId == AftJack)
+		cable.outputJackId = MidiAftPolyJack;
+
+	else if (cable.outputJackId == RetrigJack)
+		cable.outputJackId = MidiRetrigPolyJack;
+
+	else {
+		// Non-poly jacks (PW, MW, Clock, etc.) use existing mono mapping
+		mapMidiCVJack(cable, midi_chan);
+		return;
+	}
+
+	cable.outputJackId = MetaModule::Midi::set_midi_channel(cable.outputJackId, midi_chan);
+	mapInputJack(cable);
 }
 
 void PatchFileWriter::mapMidiCVPolySplitJack(CableMap &cable, unsigned monoJackId, unsigned midi_chan) {

--- a/src/mapping/patch_writer.hh
+++ b/src/mapping/patch_writer.hh
@@ -48,6 +48,7 @@ private:
 	void mapMidiGateJack(CableMap &map, unsigned midi_chan);
 	void mapMidiCCJack(CableMap &cable, MIDI::MidiCCCVSettings const &cccv_settings);
 
+	void mapMidiCVPolyJack(CableMap &cable, uint32_t midi_chan);
 	void mapMidiCVPolySplitJack(CableMap &cable, unsigned monoJackId, unsigned midi_chan);
 
 	void setModuleList(std::vector<BrandModule> &modules);

--- a/src/mapping/vcv_patch_file_writer.hh
+++ b/src/mapping/vcv_patch_file_writer.hh
@@ -36,6 +36,7 @@ struct VCVPatchFileWriter {
 		bool use_glue_labels = true;
 		bool use_builtin_midi = true;
 		const std::map<int64_t, std::string> &module_aliases;
+		bool auto_map_audio_outs = false;
 	};
 
 	static std::string createPatchYml(FileFields data) {
@@ -50,6 +51,7 @@ struct VCVPatchFileWriter {
 		auto use_glue_labels = data.use_glue_labels;
 		auto use_builtin_midi = data.use_builtin_midi;
 		auto &module_aliases = data.module_aliases;
+		auto auto_map_audio_outs = data.auto_map_audio_outs;
 
 		auto context = rack::contextGet();
 		auto engine = context->engine;
@@ -190,6 +192,43 @@ struct VCVPatchFileWriter {
 						.inputModuleId = in->getId(),
 						.lv_color_full = cable_color_rgb565(cableWidget),
 					});
+				}
+			}
+		}
+
+		// Auto-map source of AudioInterface inputs to unpatched Hub panel outs
+		if (auto_map_audio_outs) {
+			for (auto cableWidget : APP->scene->rack->getCompleteCables()) {
+				auto cable = cableWidget->cable;
+				auto *out = cable->outputModule;
+				auto *in = cable->inputModule;
+
+				// regular module out -> AudioInterface In
+				if (ModuleDirectory::isAudioInterface(in) && ModuleDirectory::isRegularModule(out, use_builtin_midi)) {
+
+					bool hasPanelOutCable = false;
+					for (auto const &c : cableData) {
+						// Check if hub has a cable on that jack
+						if ((c.inputModuleId == hubModuleId) && c.inputJackId == cable->inputId) {
+							hasPanelOutCable = true;
+							break;
+						}
+						// Check if audio expander has a cable on that jack
+						if (expanders.isKnownJackExpander(c.inputModuleId) && (c.inputJackId + 8) == cable->inputId) {
+							hasPanelOutCable = true;
+							break;
+						}
+					}
+					if (!hasPanelOutCable) {
+						CableMap synthesized{
+							.outputJackId = cable->outputId,
+							.inputJackId = cable->inputId,
+							.outputModuleId = out->getId(),
+							.inputModuleId = hubModuleId,
+							.lv_color_full = cable_color_rgb565(cableWidget),
+						};
+						cableData.push_back(synthesized);
+					}
 				}
 			}
 		}

--- a/src/mapping/vcv_patch_file_writer.hh
+++ b/src/mapping/vcv_patch_file_writer.hh
@@ -74,7 +74,7 @@ struct VCVPatchFileWriter {
 
 				auto *module = engine->getModule(moduleID);
 
-				addModuleToMapping(module, moduleData, paramData, midimodules, expanders);
+				addModuleToMapping(module, moduleData, paramData, midimodules, expanders, use_builtin_midi);
 			}
 		}
 
@@ -108,7 +108,7 @@ struct VCVPatchFileWriter {
 
 			for (auto module_id : connected_modules) {
 				if (auto *module = engine->getModule(module_id))
-					addModuleToMapping(module, moduleData, paramData, midimodules, expanders);
+					addModuleToMapping(module, moduleData, paramData, midimodules, expanders, use_builtin_midi);
 			}
 		}
 
@@ -117,7 +117,7 @@ struct VCVPatchFileWriter {
 			// Add modules joined to the left of the hub module
 			auto *module = engine->getModule(hubModuleId);
 			while (module) {
-				addModuleToMapping(module, moduleData, paramData, midimodules, expanders);
+				addModuleToMapping(module, moduleData, paramData, midimodules, expanders, use_builtin_midi);
 
 				if (module->leftExpander.moduleId < 0)
 					break;
@@ -131,7 +131,7 @@ struct VCVPatchFileWriter {
 			// Add modules joined to the right of the hub module
 			auto *module = engine->getModule(hubModuleId);
 			while (module) {
-				addModuleToMapping(module, moduleData, paramData, midimodules, expanders);
+				addModuleToMapping(module, moduleData, paramData, midimodules, expanders, use_builtin_midi);
 
 				if (module->rightExpander.moduleId < 0)
 					break;
@@ -148,9 +148,11 @@ struct VCVPatchFileWriter {
 			cables.push_back(engine->getCable(id));
 		}
 
-		// Scan cables for MIDICV -> Split connections
-		for (auto cable : cables) {
-			midimodules.addPolySplitCable(cable);
+		// Scan cables for MIDICV -> Split connections (Built-In mode only)
+		if (use_builtin_midi) {
+			for (auto cable : cables) {
+				midimodules.addPolySplitCable(cable);
+			}
 		}
 
 		// Scan cables
@@ -163,10 +165,13 @@ struct VCVPatchFileWriter {
 
 			// The output module must be in the patch, or a Core MIDI module, or a Split module connected to a Core MIDI module.
 			bool isKnownOutModule = ModuleDirectory::isRegularModule(out) || ModuleDirectory::isHubOrExpander(out) ||
-									ModuleDirectory::isCoreMIDI(out) || midimodules.isPolySplitModule(out);
+									ModuleDirectory::isCoreMIDI(out) || midimodules.isPolySplitModule(out) ||
+									(!use_builtin_midi && ModuleDirectory::isCoreSplitMerge(out));
 
 			// The input module must be in the patch
-			bool isKnownInputModule = ModuleDirectory::isRegularModule(in) || ModuleDirectory::isHubOrExpander(in);
+			bool isKnownInputModule =
+				ModuleDirectory::isRegularModule(in) || ModuleDirectory::isHubOrExpander(in) ||
+				(!use_builtin_midi && (ModuleDirectory::isCoreMIDI(in) || ModuleDirectory::isCoreSplitMerge(in)));
 
 			if (isKnownOutModule || isKnownInputModule) {
 
@@ -215,8 +220,9 @@ struct VCVPatchFileWriter {
 								auto *textVal = json_object_get(label, "text");
 								auto *idVal = json_object_get(label, "moduleId");
 								auto *yVal = json_object_get(label, "y");
-								if (textVal && idVal && json_is_string(textVal) && json_is_integer(idVal)
-								&& json_string_value(textVal)[0] != '\0') {
+								if (textVal && idVal && json_is_string(textVal) && json_is_integer(idVal) &&
+									json_string_value(textVal)[0] != '\0')
+								{
 									int64_t vcv_mod_id = json_integer_value(idVal);
 									float y = yVal ? (float)json_number_value(yVal) : 0.f;
 									auto it = moduleAliases.find(vcv_mod_id);
@@ -253,7 +259,12 @@ struct VCVPatchFileWriter {
 		// Add bypass state from Module::isBypassed()
 		for (auto moduleID : engine->getModuleIds()) {
 			auto *module = engine->getModule(moduleID);
-			if (ModuleDirectory::isRegularModule(module)) {
+
+			// Make sure the module is a regular module OR we are including MIDI modules
+			if (ModuleDirectory::isRegularModule(module) ||
+				(!use_builtin_midi &&
+				 (ModuleDirectory::isCoreMIDI(module) || ModuleDirectory::isCoreSplitMerge(module))))
+			{
 				pw.addModuleStateJson(module);
 				pw.addBypassedModule(module);
 			}
@@ -331,7 +342,8 @@ struct VCVPatchFileWriter {
 								   std::vector<BrandModule> &moduleData,
 								   std::vector<ParamMap> &paramData,
 								   MIDI::Modules &midimodules,
-								   ExpanderMappings &expanders) {
+								   ExpanderMappings &expanders,
+								   bool use_builtin_midi = true) {
 
 		if (ModuleDirectory::isRegularModule(module)) {
 			int64_t moduleID = module->getId();
@@ -354,7 +366,32 @@ struct VCVPatchFileWriter {
 				}
 			}
 		}
-		midimodules.addMidiModule(module);
+
+		if (!use_builtin_midi && (ModuleDirectory::isCoreMIDI(module) || ModuleDirectory::isCoreSplitMerge(module))) {
+			// RackCore mode: add MIDI/Split/Merge as regular modules
+			int64_t moduleID = module->getId();
+			auto moduleWidget = APP->scene->rack->getModule(moduleID);
+			if (moduleWidget) {
+				std::string brand_module;
+				if (ModuleDirectory::isCoreMIDI(module))
+					brand_module = std::string("RackCore:") + module->getModel()->slug;
+				else
+					brand_module = ModuleDirectory::convertSlugs(module);
+
+				moduleData.push_back({moduleID,
+									  brand_module.c_str(),
+									  moduleWidget->getBox().getLeft(),
+									  moduleWidget->getBox().getTop()});
+			}
+
+			for (size_t i = 0; i < module->paramQuantities.size(); i++) {
+				float val = module->getParamQuantity(i)->getScaledValue();
+				paramData.push_back({.value = val, .paramID = (int)i, .moduleID = moduleID});
+			}
+		} else {
+			midimodules.addMidiModule(module);
+		}
+
 		expanders.addModule(module);
 	}
 

--- a/src/mapping/vcv_patch_file_writer.hh
+++ b/src/mapping/vcv_patch_file_writer.hh
@@ -34,6 +34,7 @@ struct VCVPatchFileWriter {
 		unsigned suggested_samplerate;
 		unsigned suggested_blocksize;
 		bool use_glue_labels = true;
+		bool use_builtin_midi = true;
 		const std::map<int64_t, std::string> &module_aliases;
 	};
 
@@ -47,6 +48,7 @@ struct VCVPatchFileWriter {
 		auto suggested_samplerate = data.suggested_samplerate;
 		auto suggested_blocksize = data.suggested_blocksize;
 		auto use_glue_labels = data.use_glue_labels;
+		auto use_builtin_midi = data.use_builtin_midi;
 		auto &module_aliases = data.module_aliases;
 
 		auto context = rack::contextGet();

--- a/src/mapping/vcv_patch_file_writer.hh
+++ b/src/mapping/vcv_patch_file_writer.hh
@@ -155,6 +155,13 @@ struct VCVPatchFileWriter {
 			for (auto cable : cables) {
 				midimodules.addPolySplitCable(cable);
 			}
+
+			// Remove Split modules that are directly connected to a MIDIToCVInterface:
+			// their outputs are replaced by virtual MIDI->downstream mappings.
+			std::erase_if(moduleData,
+						  [&](BrandModule const &m) { return midimodules.isPolySplitModule(m.id); });
+			std::erase_if(paramData,
+						  [&](ParamMap const &p) { return midimodules.isPolySplitModule(p.moduleID); });
 		}
 
 		// Scan cables
@@ -204,7 +211,8 @@ struct VCVPatchFileWriter {
 				auto *in = cable->inputModule;
 
 				// regular module out -> AudioInterface In
-				if (ModuleDirectory::isAudioInterface(in) && ModuleDirectory::isRegularModule(out, use_builtin_midi)) {
+				if (ModuleDirectory::isAudioInterface(in) && ModuleDirectory::isRegularModule(out, use_builtin_midi) &&
+					!(use_builtin_midi && midimodules.isPolySplitModule(out))) {
 
 					bool hasPanelOutCable = false;
 					for (auto const &c : cableData) {
@@ -300,6 +308,8 @@ struct VCVPatchFileWriter {
 
 			// Make sure the module is a regular module OR we are including MIDI modules
 			if (ModuleDirectory::isRegularModule(module, use_builtin_midi)) {
+				if (use_builtin_midi && midimodules.isPolySplitModule(module))
+					continue;
 				pw.addModuleStateJson(module);
 				pw.addBypassedModule(module);
 			}

--- a/src/mapping/vcv_patch_file_writer.hh
+++ b/src/mapping/vcv_patch_file_writer.hh
@@ -340,6 +340,8 @@ struct VCVPatchFileWriter {
 								   MIDI::Modules &midimodules,
 								   ExpanderMappings &expanders,
 								   bool use_builtin_midi = true) {
+		if (isGlueModule(module))
+			return;
 
 		if (ModuleDirectory::isRegularModule(module, use_builtin_midi)) {
 			int64_t moduleID = module->getId();

--- a/src/mapping/vcv_patch_file_writer.hh
+++ b/src/mapping/vcv_patch_file_writer.hh
@@ -164,14 +164,13 @@ struct VCVPatchFileWriter {
 			auto in = cable->inputModule;
 
 			// The output module must be in the patch, or a Core MIDI module, or a Split module connected to a Core MIDI module.
-			bool isKnownOutModule = ModuleDirectory::isRegularModule(out) || ModuleDirectory::isHubOrExpander(out) ||
-									ModuleDirectory::isCoreMIDI(out) || midimodules.isPolySplitModule(out) ||
-									(!use_builtin_midi && ModuleDirectory::isCoreSplitMerge(out));
+			bool isKnownOutModule = ModuleDirectory::isRegularModule(out, use_builtin_midi) ||
+									ModuleDirectory::isHubOrExpander(out) || ModuleDirectory::isCoreMIDI(out) ||
+									midimodules.isPolySplitModule(out);
 
 			// The input module must be in the patch
 			bool isKnownInputModule =
-				ModuleDirectory::isRegularModule(in) || ModuleDirectory::isHubOrExpander(in) ||
-				(!use_builtin_midi && (ModuleDirectory::isCoreMIDI(in) || ModuleDirectory::isCoreSplitMerge(in)));
+				ModuleDirectory::isRegularModule(in, use_builtin_midi) || ModuleDirectory::isHubOrExpander(in);
 
 			if (isKnownOutModule || isKnownInputModule) {
 
@@ -261,10 +260,7 @@ struct VCVPatchFileWriter {
 			auto *module = engine->getModule(moduleID);
 
 			// Make sure the module is a regular module OR we are including MIDI modules
-			if (ModuleDirectory::isRegularModule(module) ||
-				(!use_builtin_midi &&
-				 (ModuleDirectory::isCoreMIDI(module) || ModuleDirectory::isCoreSplitMerge(module))))
-			{
+			if (ModuleDirectory::isRegularModule(module, use_builtin_midi)) {
 				pw.addModuleStateJson(module);
 				pw.addBypassedModule(module);
 			}
@@ -345,11 +341,18 @@ struct VCVPatchFileWriter {
 								   ExpanderMappings &expanders,
 								   bool use_builtin_midi = true) {
 
-		if (ModuleDirectory::isRegularModule(module)) {
+		if (ModuleDirectory::isRegularModule(module, use_builtin_midi)) {
 			int64_t moduleID = module->getId();
-			auto brand_module = ModuleDirectory::convertSlugs(module);
 			auto moduleWidget = APP->scene->rack->getModule(moduleID);
 			if (moduleWidget) {
+
+				std::string brand_module;
+				// RackCore mode: add MIDI/Split/Merge as regular modules
+				if (use_builtin_midi || !ModuleDirectory::isCoreMIDI(module))
+					brand_module = ModuleDirectory::convertSlugs(module);
+				else
+					brand_module = std::string("RackCore:") + module->getModel()->slug;
+
 				moduleData.push_back({moduleID,
 									  brand_module.c_str(),
 									  moduleWidget->getBox().getLeft(),
@@ -367,28 +370,7 @@ struct VCVPatchFileWriter {
 			}
 		}
 
-		if (!use_builtin_midi && (ModuleDirectory::isCoreMIDI(module) || ModuleDirectory::isCoreSplitMerge(module))) {
-			// RackCore mode: add MIDI/Split/Merge as regular modules
-			int64_t moduleID = module->getId();
-			auto moduleWidget = APP->scene->rack->getModule(moduleID);
-			if (moduleWidget) {
-				std::string brand_module;
-				if (ModuleDirectory::isCoreMIDI(module))
-					brand_module = std::string("RackCore:") + module->getModel()->slug;
-				else
-					brand_module = ModuleDirectory::convertSlugs(module);
-
-				moduleData.push_back({moduleID,
-									  brand_module.c_str(),
-									  moduleWidget->getBox().getLeft(),
-									  moduleWidget->getBox().getTop()});
-			}
-
-			for (size_t i = 0; i < module->paramQuantities.size(); i++) {
-				float val = module->getParamQuantity(i)->getScaledValue();
-				paramData.push_back({.value = val, .paramID = (int)i, .moduleID = moduleID});
-			}
-		} else {
+		if (use_builtin_midi) {
 			midimodules.addMidiModule(module);
 		}
 

--- a/src/mapping/vcv_patch_file_writer.hh
+++ b/src/mapping/vcv_patch_file_writer.hh
@@ -421,7 +421,10 @@ struct VCVPatchFileWriter {
 			}
 		}
 
-		if (use_builtin_midi) {
+		// In built-in MIDI mode, convert every Core MIDI module into patch MIDI settings.
+		// MIDI-Map is always converted (even in RackCore MIDI mode): its CC->param mappings
+		// become the patch's MIDI map, and the module itself is never added to the patch.
+		if (use_builtin_midi || ModuleDirectory::isMidiMap(module)) {
 			midimodules.addMidiModule(module);
 		}
 

--- a/tests/rack.hpp
+++ b/tests/rack.hpp
@@ -1,8 +1,16 @@
 #pragma once
 #include "jansson.h"
 #include <array>
+#include <cstdint>
 #include <string>
 #include <vector>
+
+// In a real build, rack's logger.hpp provides WARN(). doctest.h also defines a
+// WARN() assertion macro, which collides. Replace it with a no-op for tests.
+#ifdef WARN
+#undef WARN
+#endif
+#define WARN(...) ((void)0)
 
 namespace rack::app
 {
@@ -44,6 +52,12 @@ struct Module {
 	Model *getModel() {
 		return model;
 	}
+	int64_t getId() {
+		return id;
+	}
+	bool isBypassed() {
+		return false;
+	}
 };
 
 struct ParamHandle {
@@ -55,7 +69,12 @@ struct ParamHandle {
 	NVGcolor color;
 };
 
-struct Cable {};
+struct Cable {
+	Module *inputModule = nullptr;
+	Module *outputModule = nullptr;
+	int outputId = 0;
+	int inputId = 0;
+};
 
 struct _Engine {
 	void removeParamHandle(rack::ParamHandle *) {


### PR DESCRIPTION
Companion PR to https://github.com/4ms/metamodule/pull/563

Adds polyphonic MIDI support.

Previous versions of the 4ms VCV plugin would detect a MIDI->CV module patched into Split module, and replace those modules with native MIDI mappings for each of the each of the poly channels. In all cases, Split modules (and the Merge module) would be removed from the patch.

The PR adds a context menu item to select "built-in" or "RackCore" MIDI mode. 
Built-in mode acts like the existing behavior. It allows patching MIDI->CV modules directly to other modules, and creates a cable with the new polyphonic MIDI mapping IDs. The firmware handles the polyphonic connections, so no Split module is needed.
RackCore mode replaces the MIDI CV and Split modules with their RackCore ports in firmware.


- [x] Context menu item for selecting Built-in or RackCore MIDI maps in patch yaml file:
    - Use built-in MIDI: Convert Core MIDI modules to native MetaModule MIDI mappings. Better CPU efficiency but fewer options and control
     - Use RackCore module: Use RackCore brand modules to replace VCV Core MIDI modules. Uses more CPU, but allows for finer control of MIDI options (e.g. pitch wheel smoothing, voice re-alloc algorithm, etc)
- [x] Allow Split and Merge and Sum in patches from VCV (change made in VCV plugin)
    - [x] Do not remove Split and Merge modules in Built-in MIDI mode if they are not used as the legacy MIDI->Split way
- [ ] ~~Add 4-port split and merge modules to 4ms plugin~~