### PR TITLE
feat: add editable range sliders

### DIFF
--- a/src/hub/hub_knob_map_button.hh
+++ b/src/hub/hub_knob_map_button.hh
@@ -94,11 +94,11 @@ public:
 					menu->addChild(new rack::MenuSeparator);
 				}
 
-				auto mn = new RangeSlider<RangePart::Min>(hub, paramObj);
+				auto mn = new EditableRangeSlider<RangePart::Min>(hub, paramObj);
 				mn->box.size.x = 100;
 				menu->addChild(mn);
 
-				auto mx = new RangeSlider<RangePart::Max>(hub, paramObj);
+				auto mx = new EditableRangeSlider<RangePart::Max>(hub, paramObj);
 				mx->box.size.x = 100;
 				menu->addChild(mx);
 			}

--- a/src/mapping/range_slider.hh
+++ b/src/mapping/range_slider.hh
@@ -1,6 +1,7 @@
 #pragma once
 #include "MappableObject.h"
 #include "hub/hub_module.hh"
+#include "mapping/range_value_parser.hh"
 #include <rack.hpp>
 #include <cmath>
 #include <cstdio>
@@ -117,7 +118,8 @@ private:
 			return;
 		submitting = true;
 
-		double val = te_interp(text.c_str(), nullptr);
+		const auto expr = normalizeRangeValueExpression(text);
+		double val = te_interp(expr.c_str(), nullptr);
 		if (std::isnan(val)) {
 			if (onCancel)
 				onCancel();

--- a/src/mapping/range_slider.hh
+++ b/src/mapping/range_slider.hh
@@ -23,7 +23,7 @@ private:
 
 public:
 	MappedRangeQuantity(MetaModuleHubBase *hub, MappableObj paramObj)
-		: _paramObj{MINMAX == RangePart::Min ? "Min: " : "Max"}
+		: _paramObj{MINMAX == RangePart::Min ? "Min" : "Max"}
 		, hub{hub}
 		, _dst_id{paramObj} {
 	}

--- a/src/mapping/range_slider.hh
+++ b/src/mapping/range_slider.hh
@@ -2,6 +2,10 @@
 #include "MappableObject.h"
 #include "hub/hub_module.hh"
 #include <rack.hpp>
+#include <cmath>
+#include <cstdio>
+#include <functional>
+#include <tinyexpr.h>
 
 namespace MetaModule
 {
@@ -49,15 +53,162 @@ public:
 	// clang-format on
 };
 
+// Internal slider - takes quantity from parent, doesn't own it
 template<RangePart MINMAX>
 struct RangeSlider : rack::ui::Slider {
+	std::function<void()> onEditRequested;
 
-public:
-	RangeSlider(MetaModuleHubBase *hub, MappableObj paramObj) {
-		quantity = new MappedRangeQuantity<MINMAX>{hub, paramObj};
+	RangeSlider(MappedRangeQuantity<MINMAX> *qty) {
+		quantity = qty;
 	}
 	~RangeSlider() {
+		quantity = nullptr; // Don't delete - owned by parent
+	}
+
+	void onDoubleClick(const DoubleClickEvent &e) override {
+		if (onEditRequested) {
+			onEditRequested();
+			e.consume(this);
+			return;
+		}
+		rack::ui::Slider::onDoubleClick(e);
+	}
+};
+
+// Text field for precise value entry
+struct RangeTextField : rack::ui::TextField {
+	std::function<void(float)> onSubmit;
+	std::function<void()> onCancel;
+	bool submitting = false;
+	bool cancelling = false;
+
+	void onSelectKey(const SelectKeyEvent &e) override {
+		if (e.action == GLFW_PRESS || e.action == GLFW_REPEAT) {
+			if (e.key == GLFW_KEY_ENTER || e.key == GLFW_KEY_KP_ENTER) {
+				submitValue();
+				e.consume(this);
+				return;
+			}
+			if (e.key == GLFW_KEY_ESCAPE) {
+				cancelValue();
+				e.consume(this);
+				return;
+			}
+		}
+		rack::ui::TextField::onSelectKey(e);
+	}
+
+	void onDeselect(const DeselectEvent &e) override {
+		if (!cancelling)
+			submitValue();
+		cancelling = false;
+		rack::ui::TextField::onDeselect(e);
+	}
+
+private:
+	void cancelValue() {
+		cancelling = true;
+		if (onCancel)
+			onCancel();
+	}
+
+	void submitValue() {
+		if (submitting)
+			return;
+		submitting = true;
+
+		double val = te_interp(text.c_str(), nullptr);
+		if (std::isnan(val)) {
+			if (onCancel)
+				onCancel();
+		} else {
+			if (onSubmit)
+				onSubmit(static_cast<float>(val));
+		}
+
+		submitting = false;
+	}
+};
+
+// Composite widget: slider + text field, toggles on double-click
+template<RangePart MINMAX>
+struct EditableRangeSlider : rack::widget::Widget {
+private:
+	MappedRangeQuantity<MINMAX> *quantity = nullptr;
+	RangeSlider<MINMAX> *slider = nullptr;
+	RangeTextField *textField = nullptr;
+
+public:
+	EditableRangeSlider(MetaModuleHubBase *hub, MappableObj paramObj) {
+		quantity = new MappedRangeQuantity<MINMAX>{hub, paramObj};
+
+		slider = new RangeSlider<MINMAX>(quantity);
+		slider->onEditRequested = [this]() { switchToTextMode(); };
+		slider->box.pos = rack::math::Vec(0, 0);
+		addChild(slider);
+
+		textField = new RangeTextField();
+		textField->box.pos = rack::math::Vec(0, 0);
+		textField->hide();
+		addChild(textField);
+
+		textField->onSubmit = [this](float displayVal) {
+			displayVal = rack::math::clamp(displayVal, 0.f, 100.f);
+			quantity->setDisplayValue(displayVal);
+			switchToSliderMode();
+		};
+
+		textField->onCancel = [this]() { switchToSliderMode(); };
+
+		box.size = rack::math::Vec(100, 20);
+	}
+
+	~EditableRangeSlider() {
 		delete quantity;
+	}
+
+	void onButton(const ButtonEvent &e) override {
+		if (e.action == GLFW_PRESS && e.button == GLFW_MOUSE_BUTTON_RIGHT) {
+			switchToTextMode();
+			e.consume(this);
+			return;
+		}
+
+		rack::widget::Widget::onButton(e);
+
+		if (!e.isConsumed() && e.button == GLFW_MOUSE_BUTTON_LEFT)
+			e.consume(this);
+	}
+
+	void onDoubleClick(const DoubleClickEvent &e) override {
+		switchToTextMode();
+		e.consume(this);
+	}
+
+	void draw(const DrawArgs &args) override {
+		slider->box.size = box.size;
+		textField->box.size = box.size;
+		rack::widget::Widget::draw(args);
+	}
+
+private:
+	void switchToTextMode() {
+		slider->hide();
+
+		// Pre-populate with current value
+		char buf[16];
+		std::snprintf(buf, sizeof(buf), "%.1f", quantity->getDisplayValue());
+		textField->setText(buf);
+		textField->selectAll();
+		textField->show();
+
+		APP->event->setSelectedWidget(textField);
+	}
+
+	void switchToSliderMode() {
+		textField->hide();
+		slider->show();
+		APP->event->setSelectedWidget(nullptr);
 	}
 };
 

--- a/src/mapping/range_slider.hh
+++ b/src/mapping/range_slider.hh
@@ -180,11 +180,6 @@ public:
 			e.consume(this);
 	}
 
-	void onDoubleClick(const DoubleClickEvent &e) override {
-		switchToTextMode();
-		e.consume(this);
-	}
-
 	void draw(const DrawArgs &args) override {
 		slider->box.size = box.size;
 		textField->box.size = box.size;

--- a/src/mapping/range_value_parser.hh
+++ b/src/mapping/range_value_parser.hh
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <algorithm>
+#include <string>
+
+namespace MetaModule
+{
+
+inline std::string normalizeRangeValueExpression(std::string text) {
+	text.erase(std::remove(text.begin(), text.end(), '%'), text.end());
+	return text;
+}
+
+} // namespace MetaModule

--- a/tests/range_value_parser_tests.cc
+++ b/tests/range_value_parser_tests.cc
@@ -1,0 +1,9 @@
+#include "doctest.h"
+#include "mapping/range_value_parser.hh"
+
+TEST_CASE("normalizeRangeValueExpression removes percent signs") {
+	CHECK(MetaModule::normalizeRangeValueExpression("50%") == "50");
+	CHECK(MetaModule::normalizeRangeValueExpression("100/7%") == "100/7");
+	CHECK(MetaModule::normalizeRangeValueExpression(" 50 % ") == " 50  ");
+	CHECK(MetaModule::normalizeRangeValueExpression("25") == "25");
+}


### PR DESCRIPTION
# feat: add editable range sliders

## Summary
- Adds precise text entry for hub knob mapping Min/Max range controls.
- Range values can now be adjusted either by dragging the slider or by opening a text field with right-click or double-click.
- Text entry accepts numeric expressions and clamps the final range value to 0-100%.

## Behavior
- Enter applies the typed value.
- Escape cancels text entry and returns to the slider.
- Clicking away submits the current text field value.
- Invalid expressions cancel without changing the range.

## Test Plan
- [x] `make tests`
- [x] `cmake --build build --target plugin -- -j 8`
- [x] Manual Rack smoke test:
  - Drag Min/Max sliders in the hub knob mapping menu.
  - Right-click and double-click Min/Max sliders to enter text mode.
  - Press Enter with a valid value and confirm it applies.
  - Press Escape with a valid edited value and confirm it does not apply.
  - Enter an invalid expression and confirm it cancels without applying.
  - Click inside the visible text field and confirm caret/selection behavior works normally.

## Notes
- Branch: `editable-range-sliders`
- Commit: `867d0b2 feat: add editable range sliders`
