### PR TITLE
feat: persist Hub settings across new module installations

### DIFF
--- a/src/hub/hub_medium.cc
+++ b/src/hub/hub_medium.cc
@@ -72,6 +72,10 @@ private:
 
 std::string wifiUrl = "";
 Volume wifiVolume = Volume::Card;
+MappingMode defaultMappingMode = MappingMode::ALL;
+bool defaultUseGlueLabels = true;
+bool defaultUseBuiltinMidi = true;
+bool defaultAutoMapAudioOuts = false;
 
 struct HubMediumWidget : MetaModuleHubWidget {
 
@@ -368,7 +372,10 @@ struct HubMediumWidget : MetaModuleHubWidget {
 			"Include modules from:",
 			mappingModeLabels,
 			[this]() { return hubModule->mappingMode; },
-			[this](size_t index) { hubModule->setMappingMode(index); }));
+			[this](size_t index) {
+				hubModule->setMappingMode(index);
+				defaultMappingMode = MappingMode(index);
+			}));
 		menu->addChild(new MenuSeparator());
 		menu->addChild(createMenuItem("Set Wi-Fi Expander address", "", [this]() { promptWifiUrl(); }));
 		menu->addChild(createIndexSubmenuItem(
@@ -538,7 +545,10 @@ struct HubMediumWidget : MetaModuleHubWidget {
 			"Use stoermelder GLUE labels for module aliases",
 			"",
 			[this]() { return hubModule->use_glue_labels; },
-			[this]() { hubModule->use_glue_labels = !hubModule->use_glue_labels; }));
+			[this]() {
+				hubModule->use_glue_labels = !hubModule->use_glue_labels;
+				defaultUseGlueLabels = hubModule->use_glue_labels;
+			}));
 
 		menu->addChild(new MenuSeparator());
 
@@ -561,18 +571,27 @@ struct HubMediumWidget : MetaModuleHubWidget {
 			"Use built-in MIDI",
 			"",
 			[this]() { return hubModule->use_builtin_midi; },
-			[this]() { hubModule->use_builtin_midi = true; }));
+			[this]() {
+				hubModule->use_builtin_midi = true;
+				defaultUseBuiltinMidi = true;
+			}));
 		menu->addChild(createCheckMenuItem(
 			"Use RackCore MIDI",
 			"",
 			[this]() { return !hubModule->use_builtin_midi; },
-			[this]() { hubModule->use_builtin_midi = false; }));
+			[this]() {
+				hubModule->use_builtin_midi = false;
+				defaultUseBuiltinMidi = false;
+			}));
 		menu->addChild(new MenuSeparator());
 		menu->addChild(createCheckMenuItem(
 			"Automatically map AudioInterface to panel outs",
 			"",
 			[this]() { return hubModule->auto_map_audio_outs; },
-			[this]() { hubModule->auto_map_audio_outs = !hubModule->auto_map_audio_outs; }));
+			[this]() {
+				hubModule->auto_map_audio_outs = !hubModule->auto_map_audio_outs;
+				defaultAutoMapAudioOuts = hubModule->auto_map_audio_outs;
+			}));
 	}
 
 	std::string formatWifiStatus() {

--- a/src/hub/hub_module.hh
+++ b/src/hub/hub_module.hh
@@ -226,9 +226,14 @@ struct MetaModuleHubBase : public rack::Module {
 			mappings.changeActiveKnobSet(idx, ShouldLock::No);
 		}
 
+		// For settings with global user defaults: a patch saved before the setting
+		// existed has no key for it, so use the legacy default, not the user default,
+		// to keep old patches working as they always did
 		auto mappingModeJ = json_object_get(rootJ, "MappingMode");
 		if (json_is_integer(mappingModeJ)) {
 			mappingMode = MappingMode(json_integer_value(mappingModeJ));
+		} else {
+			mappingMode = MappingMode::ALL;
 		}
 
 		auto suggSampleRateJ = json_object_get(rootJ, "SuggestedSampleRate");
@@ -255,16 +260,13 @@ struct MetaModuleHubBase : public rack::Module {
 		jack_alias.decodeJson(aliasJ);
 
 		auto useGlueLabelsJ = json_object_get(rootJ, "UseGlueLabels");
-		if (json_is_boolean(useGlueLabelsJ))
-			use_glue_labels = json_boolean_value(useGlueLabelsJ);
+		use_glue_labels = json_is_boolean(useGlueLabelsJ) ? json_boolean_value(useGlueLabelsJ) : true;
 
 		auto useBuiltinMidiJ = json_object_get(rootJ, "UseBuiltinMidi");
-		if (json_is_boolean(useBuiltinMidiJ))
-			use_builtin_midi = json_boolean_value(useBuiltinMidiJ);
+		use_builtin_midi = json_is_boolean(useBuiltinMidiJ) ? json_boolean_value(useBuiltinMidiJ) : true;
 
 		auto autoMapAudioOutsJ = json_object_get(rootJ, "AutoMapAudioOuts");
-		if (json_is_boolean(autoMapAudioOutsJ))
-			auto_map_audio_outs = json_boolean_value(autoMapAudioOutsJ);
+		auto_map_audio_outs = json_is_boolean(autoMapAudioOutsJ) ? json_boolean_value(autoMapAudioOutsJ) : false;
 
 		auto moduleAliasesJ = json_object_get(rootJ, "ModuleAliases");
 		if (json_is_object(moduleAliasesJ)) {

--- a/src/hub/hub_module.hh
+++ b/src/hub/hub_module.hh
@@ -25,7 +25,7 @@ struct MetaModuleHubBase : public rack::Module {
 	std::function<void()> updatePatchName;
 	std::string patchNameText = "";
 	std::string patchDescText = "";
-	MappingMode mappingMode = MetaModule::MappingMode::ALL;
+	MappingMode mappingMode = MetaModule::defaultMappingMode;
 
 	bool should_save = false;
 	bool should_send_wifi = false;
@@ -38,9 +38,9 @@ struct MetaModuleHubBase : public rack::Module {
 
 	JackAlias jack_alias{};
 
-	bool use_glue_labels = true;
-	bool use_builtin_midi = true;
-	bool auto_map_audio_outs = false;
+	bool use_glue_labels = defaultUseGlueLabels;
+	bool use_builtin_midi = defaultUseBuiltinMidi;
+	bool auto_map_audio_outs = defaultAutoMapAudioOuts;
 	std::map<int64_t, std::string> module_aliases;
 	std::map<int64_t, int> module_alias_colors;
 
@@ -297,10 +297,6 @@ struct MetaModuleHubBase : public rack::Module {
 		Module::onReset(e);
 		patchNameText = "";
 		patchDescText = "";
-		mappingMode = MetaModule::MappingMode::ALL;
-		use_glue_labels = true;
-		use_builtin_midi = true;
-		auto_map_audio_outs = false;
 		module_aliases.clear();
 		module_alias_colors.clear();
 		mappings.clear_all(ShouldLock::No);

--- a/src/plugin.cc
+++ b/src/plugin.cc
@@ -75,6 +75,10 @@ extern "C" __attribute__((__visibility__("default"))) json_t *settingsToJson() {
 	json_t *rootJ = json_object();
 	json_object_set_new(rootJ, "wifiUrl", json_string(MetaModule::wifiUrl.c_str()));
 	json_object_set_new(rootJ, "wifiPath", json_integer((unsigned)MetaModule::wifiVolume));
+	json_object_set_new(rootJ, "defaultMappingMode", json_integer((unsigned)MetaModule::defaultMappingMode));
+	json_object_set_new(rootJ, "defaultUseGlueLabels", json_boolean(MetaModule::defaultUseGlueLabels));
+	json_object_set_new(rootJ, "defaultUseBuiltinMidi", json_boolean(MetaModule::defaultUseBuiltinMidi));
+	json_object_set_new(rootJ, "defaultAutoMapAudioOuts", json_boolean(MetaModule::defaultAutoMapAudioOuts));
 	return rootJ;
 }
 
@@ -94,4 +98,19 @@ extern "C" __attribute__((__visibility__("default"))) void settingsFromJson(json
 		else if (val == (unsigned)MetaModule::Volume::Internal)
 			MetaModule::wifiVolume = MetaModule::Volume::Internal;
 	}
+
+	if (auto mappingModeJ = json_object_get(rootJ, "defaultMappingMode")) {
+		auto val = json_integer_value(mappingModeJ);
+		if (val >= 0 && val <= 4)
+			MetaModule::defaultMappingMode = MetaModule::MappingMode(val);
+	}
+
+	if (auto useGlueLabelsJ = json_object_get(rootJ, "defaultUseGlueLabels"))
+		MetaModule::defaultUseGlueLabels = json_boolean_value(useGlueLabelsJ);
+
+	if (auto useBuiltinMidiJ = json_object_get(rootJ, "defaultUseBuiltinMidi"))
+		MetaModule::defaultUseBuiltinMidi = json_boolean_value(useBuiltinMidiJ);
+
+	if (auto autoMapAudioOutsJ = json_object_get(rootJ, "defaultAutoMapAudioOuts"))
+		MetaModule::defaultAutoMapAudioOuts = json_boolean_value(autoMapAudioOutsJ);
 }

--- a/src/plugin.hh
+++ b/src/plugin.hh
@@ -9,6 +9,10 @@ enum Volume { Internal = 0, USB = 1, Card = 2 };
 enum MappingMode { ALL = 0, LEFTRIGHT = 1, RIGHT = 2, LEFT = 3, CONNECTED = 4 };
 
 extern Volume wifiVolume;
+extern MappingMode defaultMappingMode;
+extern bool defaultUseGlueLabels;
+extern bool defaultUseBuiltinMidi;
+extern bool defaultAutoMapAudioOuts;
 
 } // namespace MetaModule
 


### PR DESCRIPTION
Hey Dan, another tweak to the Hub. I think some of the settings in the context menu should be preserved across instances -- they're things most users will want to work the same way every time. The model here is the Wi-Fi settings -- of course no one wants to re-enter the MetaModule's IP address every time, and it's sensible that we remember the "Wi-Fi sends to" destination too. So I've done the same with four other settings: GLUE labels, built-in MIDI, auto-map audio outs, and mapping mode. I think it'll be more user-friendly to make these "set-and-forget" rather than "revert to the default with each new patch." Hope you agree! 

## Summary

- Hub right-click menu settings now persist at the plugin level, so new Hub instances inherit previously set preferences
- Settings that now persist: mapping mode, GLUE labels, built-in MIDI, auto-map audio outs
- Settings are saved to VCV Rack's plugin settings file (alongside existing Wi-Fi settings)
- Initialize preserves these settings (only resets patch name/description and mappings)

## Test plan

- [x] Change a Hub setting (e.g., "Include modules from" to "Connected")
- [x] Add a new Hub module — verify it inherits the setting
- [x] Restart VCV Rack — verify new Hub modules still inherit the setting
- [x] Initialize a Hub module (right-click > Initialize) — verify it preserves the setting